### PR TITLE
Add support W5500-EVB-Pico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,20 @@
 
 # Build directory
 build/
+build-*/
+_deps/
+build-w5500/
+build-w5500-ninja/
+generated/
+pico-sdk/
+pico_flash_region.ld
+
+# CMake / Visual Studio local files
+.vs/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
 
 # MacOS files
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+# Allow custom board definitions in this repository (e.g. w5500_evb_pico).
+# This must be set before importing Pico SDK so board resolution can find custom headers.
+list(APPEND PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/boards/include/boards)
+
 include(pico_sdk_import.cmake)
 set(FREERTOS_KERNEL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/FreeRTOS-Kernel)
 include(FreeRTOS_Kernel_import.cmake)
@@ -9,16 +13,21 @@ set(EI_SDK_FOLDER ${MODEL_FOLDER}/edge-impulse-sdk)
 set(DRIVERS Sensors)
 set(EI_PLATFORM_FOLDER edge-impulse)
 set(FIRMWARE_SDK_FOLDER firmware-sdk)
+set(WIZNET_W5X00_PLATFORM_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico
+)
 
-if(PICO_BOARD STREQUAL "pico")
-    set(RP_PROJCT_NAME ei_rp2040_firmware)
-else()
+if(PICO_BOARD MATCHES "^pico2")
     set(RP_PROJCT_NAME ei_rp2350_firmware)
+else()
+    set(RP_PROJCT_NAME ei_rp2040_firmware)
 endif()
 
 project(${RP_PROJCT_NAME} C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
+
+option(EI_ENABLE_MQTT_PUBLISH "Publish Edge Impulse inference result over MQTT using W5500" OFF)
 
 
 pico_sdk_init()
@@ -43,6 +52,7 @@ target_link_libraries(${RP_PROJCT_NAME}
                       pico_stdlib
                       pico_unique_id
                       hardware_gpio
+                      hardware_spi
                       hardware_adc
                       hardware_i2c
                       hardware_irq
@@ -58,6 +68,13 @@ endif()
 target_compile_definitions(${RP_PROJCT_NAME} PRIVATE
     configNUMBER_OF_CORES=2
     )
+
+if(PICO_BOARD STREQUAL "w5500_evb_pico")
+    target_compile_definitions(${RP_PROJCT_NAME} PRIVATE
+        EI_W5500_ETHERNET=1
+        _WIZCHIP_=W5500
+    )
+endif()
 
 
 target_include_directories(${RP_PROJCT_NAME} PRIVATE
@@ -84,6 +101,7 @@ target_include_directories(${RP_PROJCT_NAME} PRIVATE
     ${EI_PLATFORM_FOLDER}
     ${EI_PLATFORM_FOLDER}/ingestion-sdk-c
     ${EI_PLATFORM_FOLDER}/ingestion-sdk-platform/raspberry-rp2xxx
+    ${WIZNET_W5X00_PLATFORM_DIR}
     ${EI_PLATFORM_FOLDER}/ingestion-sdk-platform/sensors
     ${EI_PLATFORM_FOLDER}/inference
     ${FIRMWARE_SDK_FOLDER}/QCBOR/inc
@@ -96,6 +114,37 @@ target_include_directories(${RP_PROJCT_NAME} PRIVATE
     ${DRIVERS}/ADXL345
     ${DRIVERS}/PDM/src/include
 )
+
+if(PICO_BOARD STREQUAL "w5500_evb_pico")
+    target_include_directories(${RP_PROJCT_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Ethernet
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Internet/DHCP
+    )
+
+    target_sources(${RP_PROJCT_NAME} PRIVATE
+        ${WIZNET_W5X00_PLATFORM_DIR}/ei_w5500_ethernet.cpp
+    )
+endif()
+
+if(EI_ENABLE_MQTT_PUBLISH)
+    if(NOT PICO_BOARD STREQUAL "w5500_evb_pico")
+        message(FATAL_ERROR "EI_ENABLE_MQTT_PUBLISH requires PICO_BOARD=w5500_evb_pico")
+    endif()
+
+    target_compile_definitions(${RP_PROJCT_NAME} PRIVATE
+        EI_MQTT_PUBLISH=1
+    )
+
+    target_sources(${RP_PROJCT_NAME} PRIVATE
+        ${WIZNET_W5X00_PLATFORM_DIR}/ei_w5500_mqtt.cpp
+        ${WIZNET_W5X00_PLATFORM_DIR}/mqtt/MQTTClient.c
+        ${WIZNET_W5X00_PLATFORM_DIR}/mqtt/mqtt_interface.c
+    )
+
+    target_include_directories(${RP_PROJCT_NAME} PRIVATE
+        ${WIZNET_W5X00_PLATFORM_DIR}/mqtt
+    )
+endif()
 
 include_directories(${INCLUDES})
 
@@ -131,6 +180,15 @@ list(APPEND SOURCE_FILES ${PORTING_FILES})
 list(APPEND SOURCE_FILES ${FIRMWARE_SDK_FILES})
 list(APPEND SOURCE_FILES ${DRIVER_FILES})
 list(APPEND SOURCE_FILES ${MIC_FILES})
+
+if(PICO_BOARD STREQUAL "w5500_evb_pico")
+    list(APPEND SOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Ethernet/wizchip_conf.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Ethernet/socket.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Ethernet/W5500/w5500.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ioLibrary_Driver/Internet/DHCP/dhcp.c
+    )
+endif()
 
 target_sources(${RP_PROJCT_NAME} PRIVATE ${SOURCE_FILES})
 pico_add_extra_outputs(${RP_PROJCT_NAME})

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ cmake ..
 make -j4
 ```
 
+### W5500-EVB-Pico (RP2040, Ethernet disabled)
+For W5500-EVB-Pico board bring-up with RP2040 firmware path (no Ethernet initialization), build with:
+```bash
+mkdir build && cd build
+cmake .. -DPICO_BOARD=w5500_evb_pico
+make -j4
+```
+
 ### Raspberry PI Pico 2 (RP2350)
 Use following build commands to build for RP2350 based hardware:
 ```bash

--- a/boards/include/boards/w5500_evb_pico.h
+++ b/boards/include/boards/w5500_evb_pico.h
@@ -1,0 +1,96 @@
+/*
+ * W5500-EVB-Pico board definition for Pico SDK.
+ *
+ * 1st phase goal: behave like Raspberry Pi Pico (RP2040) without enabling
+ * Ethernet features in firmware.
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_W5500_EVB_PICO_H
+#define _BOARDS_W5500_EVB_PICO_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2040)
+
+// Dedicated board detection macro for W5500-EVB-Pico.
+#define WIZNET_W5500_EVB_PICO
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// W5500-EVB-Pico wiring note:
+// - SPI0 GPIO16-19 are internally wired to W5500 (MISO/CS/SCK/MOSI).
+// - GPIO20 is reserved for W5500 RSTn.
+// - GPIO21 is reserved for W5500 INTn.
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (2 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+
+#define PICO_SMPS_MODE_PIN 23
+
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 1
+#endif
+
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+#endif

--- a/edge-impulse/inference/ei_run_audio_impulse.cpp
+++ b/edge-impulse/inference/ei_run_audio_impulse.cpp
@@ -42,6 +42,9 @@
 #include "ei_device_raspberry_rp2xxx.h"
 #include "ei_microphone.h"
 #include "ei_run_impulse.h"
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+#include "ei_w5500_mqtt.h"
+#endif
 
 typedef enum
 {
@@ -109,11 +112,17 @@ void ei_run_impulse(void)
     if (continuous_mode == true) {
         if (++print_results >= (EI_CLASSIFIER_SLICES_PER_MODEL_WINDOW >> 1)) {
             ei_print_results(&ei_default_impulse, &result);
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+            (void)ei_w5500_mqtt_publish_result(&result);
+#endif
             print_results = 0;
         }
     }
     else {
         ei_print_results(&ei_default_impulse, &result);
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+        (void)ei_w5500_mqtt_publish_result(&result);
+#endif
     }
 
     if (continuous_mode == true) {

--- a/edge-impulse/inference/ei_run_fusion_impulse.cpp
+++ b/edge-impulse/inference/ei_run_fusion_impulse.cpp
@@ -43,6 +43,9 @@
 #include "ei_device_raspberry_rp2xxx.h"
 #include "ei_run_impulse.h"
 #include "firmware-sdk/ei_fusion.h"
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+#include "ei_w5500_mqtt.h"
+#endif
 
 typedef enum
 {
@@ -150,11 +153,17 @@ void ei_run_impulse(void)
     if (continuous_mode == true) {
         if (++print_results >= (EI_CLASSIFIER_SLICES_PER_MODEL_WINDOW >> 1)) {
             ei_print_results(&ei_default_impulse, &result);
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+            (void)ei_w5500_mqtt_publish_result(&result);
+#endif
             print_results = 0;
         }
     }
     else {
         ei_print_results(&ei_default_impulse, &result);
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+        (void)ei_w5500_mqtt_publish_result(&result);
+#endif
     }
 
     if (continuous_mode == true) {

--- a/edge-impulse/ingestion-sdk-platform/raspberry-rp2xxx/ei_at_handlers.cpp
+++ b/edge-impulse/ingestion-sdk-platform/raspberry-rp2xxx/ei_at_handlers.cpp
@@ -43,6 +43,9 @@
 #include "ei_fusion.h"
 #include "ei_image_lib.h"
 #include "ei_run_impulse.h"
+#if defined(EI_W5500_ETHERNET)
+#include "ei_w5500_ethernet.h"
+#endif
 #include "model-parameters/model_metadata.h"
 #include "pico/bootrom.h"
 #include <string>
@@ -449,6 +452,49 @@ bool at_get_config(void)
     return true;
 }
 
+#if defined(EI_W5500_ETHERNET)
+static bool at_netinfo(void)
+{
+    ei_w5500_ethernet_netinfo_t netinfo;
+
+    if (!ei_w5500_ethernet_get_netinfo(&netinfo)) {
+        ei_printf("[W5500] NETINFO unavailable\r\n");
+        return true;
+    }
+
+    ei_printf("[W5500] Link: %s\r\n", netinfo.phy_link == EI_W5500_PHY_LINK_ON ? "UP" : "DOWN");
+    ei_printf("[W5500] MAC: %02X:%02X:%02X:%02X:%02X:%02X\r\n",
+            netinfo.mac[0], netinfo.mac[1], netinfo.mac[2],
+            netinfo.mac[3], netinfo.mac[4], netinfo.mac[5]);
+    ei_printf("[W5500] DHCP: %s\r\n", netinfo.dhcp_leased ? "LEASED" : "NOT_LEASED");
+
+    if(netinfo.dhcp_leased)
+    {
+        ei_printf("[W5500] IP: %u.%u.%u.%u\r\n",
+                netinfo.dhcp_leased ? netinfo.ip[0] : 0,
+                netinfo.dhcp_leased ? netinfo.ip[1] : 0,
+                netinfo.dhcp_leased ? netinfo.ip[2] : 0,
+                netinfo.dhcp_leased ? netinfo.ip[3] : 0);
+        ei_printf("[W5500] SN: %u.%u.%u.%u\r\n",
+                netinfo.dhcp_leased ? netinfo.sn[0] : 0,
+                netinfo.dhcp_leased ? netinfo.sn[1] : 0,
+                netinfo.dhcp_leased ? netinfo.sn[2] : 0,
+                netinfo.dhcp_leased ? netinfo.sn[3] : 0);
+        ei_printf("[W5500] GW: %u.%u.%u.%u\r\n",
+                netinfo.dhcp_leased ? netinfo.gw[0] : 0,
+                netinfo.dhcp_leased ? netinfo.gw[1] : 0,
+                netinfo.dhcp_leased ? netinfo.gw[2] : 0,
+                netinfo.dhcp_leased ? netinfo.gw[3] : 0);
+        ei_printf("[W5500] DNS: %u.%u.%u.%u\r\n",
+                netinfo.dhcp_leased ? netinfo.dns[0] : 0,
+                netinfo.dhcp_leased ? netinfo.dns[1] : 0,
+                netinfo.dhcp_leased ? netinfo.dns[2] : 0,
+                netinfo.dhcp_leased ? netinfo.dns[3] : 0);
+    }
+    return true;
+}
+#endif
+
 ATServer *ei_at_init(EiDeviceRP2xxx *device)
 {
     ATServer *at;
@@ -555,6 +601,9 @@ ATServer *ei_at_init(EiDeviceRP2xxx *device)
         nullptr,
         at_read_raw,
         AT_READRAW_ARS);
+#if defined(EI_W5500_ETHERNET)
+    at->register_command(AT_NETINFO, AT_NETINFO_HELP_TEXT, nullptr, at_netinfo, nullptr, nullptr);
+#endif
     at->register_command(AT_BOOTMODE, AT_BOOTMODE_HELP_TEXT, at_bootmode, nullptr, nullptr, nullptr);
     return at;
 }

--- a/edge-impulse/ingestion-sdk-platform/raspberry-rp2xxx/ei_device_raspberry_rp2xxx.cpp
+++ b/edge-impulse/ingestion-sdk-platform/raspberry-rp2xxx/ei_device_raspberry_rp2xxx.cpp
@@ -137,7 +137,7 @@ void EiDeviceRP2xxx::set_state(EiState state)
 #if defined(RASPBERRYPI_PICO2_W) || defined(RASPBERRYPI_PICO_W)
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
 #endif
-#if defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO)
+#if defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO) || defined(WIZNET_W5500_EVB_PICO)
         gpio_put(LED_PIN, 1);
 #endif
 
@@ -146,7 +146,7 @@ void EiDeviceRP2xxx::set_state(EiState state)
 #if defined(RASPBERRYPI_PICO2_W) || defined(RASPBERRYPI_PICO_W)
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0);
 #endif
-#if defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO)
+#if defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO) || defined(WIZNET_W5500_EVB_PICO)
         gpio_put(LED_PIN, 0);
 #endif
         ei_sleep(50);

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_ethernet.cpp
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_ethernet.cpp
@@ -1,0 +1,444 @@
+#include "ei_w5500_ethernet.h"
+
+#if defined(EI_W5500_ETHERNET)
+
+#include "ei_classifier_porting.h"
+
+extern "C" {
+#include "dhcp.h"
+#include "socket.h"
+#include "wizchip_conf.h"
+}
+
+#include "hardware/gpio.h"
+#include "hardware/sync.h"
+#include "hardware/spi.h"
+#include "pico/stdlib.h"
+#include "pico/time.h"
+#include "pico/unique_id.h"
+
+#include <string.h>
+
+#ifndef W5500_SPI_PORT
+#define W5500_SPI_PORT spi0
+#endif
+
+#ifndef W5500_SPI_BAUDRATE_HZ
+#define W5500_SPI_BAUDRATE_HZ 10000000
+#endif
+
+#ifndef W5500_PIN_MISO
+#define W5500_PIN_MISO PICO_DEFAULT_SPI_RX_PIN
+#endif
+
+#ifndef W5500_PIN_CS
+#define W5500_PIN_CS PICO_DEFAULT_SPI_CSN_PIN
+#endif
+
+#ifndef W5500_PIN_SCK
+#define W5500_PIN_SCK PICO_DEFAULT_SPI_SCK_PIN
+#endif
+
+#ifndef W5500_PIN_MOSI
+#define W5500_PIN_MOSI PICO_DEFAULT_SPI_TX_PIN
+#endif
+
+#ifndef W5500_PIN_RST
+#define W5500_PIN_RST 20
+#endif
+
+#ifndef W5500_PIN_INT
+#define W5500_PIN_INT 21
+#endif
+
+#define DHCP_SOCKET_IDX 0
+#define DHCP_POLL_INTERVAL_MS 250
+#define DHCP_LOG_RETRY_INTERVAL_MS 10000
+#define PHY_LOG_INTERVAL_MS 5000
+
+#ifndef EI_W5500_DEBUG
+#define EI_W5500_DEBUG 0
+#endif
+
+#if EI_W5500_DEBUG
+#define W5500_DBG(fmt, ...) ei_printf("[W5500][DBG] " fmt "\r\n", ##__VA_ARGS__)
+#else
+#define W5500_DBG(fmt, ...)
+#endif
+
+static bool g_initialized = false;
+static bool g_has_lease = false;
+static uint8_t g_phy_link = PHY_LINK_OFF;
+static uint32_t g_last_dhcp_poll_ms = 0;
+static uint32_t g_last_dhcp_tick_ms = 0;
+static uint32_t g_last_dhcp_fail_log_ms = 0;
+static uint32_t g_last_phy_log_ms = 0;
+static uint32_t g_irq_state = 0;
+static uint8_t g_last_dhcp_state = 0xFF;
+
+static uint8_t g_dhcp_buffer[1024] = {0};
+
+static wiz_NetInfo g_net_info = {
+    .mac = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+    .ip = {0, 0, 0, 0},
+    .sn = {0, 0, 0, 0},
+    .gw = {0, 0, 0, 0},
+    .dns = {0, 0, 0, 0},
+    .dhcp = NETINFO_DHCP,
+};
+
+static inline uint32_t now_ms(void)
+{
+    return to_ms_since_boot(get_absolute_time());
+}
+
+static const char *dhcp_state_to_str(uint8_t state)
+{
+    switch (state) {
+        case DHCP_FAILED:
+            return "FAILED";
+        case DHCP_RUNNING:
+            return "RUNNING";
+        case DHCP_IP_ASSIGN:
+            return "IP_ASSIGN";
+        case DHCP_IP_CHANGED:
+            return "IP_CHANGED";
+        case DHCP_IP_LEASED:
+            return "IP_LEASED";
+        case DHCP_STOPPED:
+            return "STOPPED";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+static void log_net_info(void)
+{
+    W5500_DBG("[W5500] MAC %02X:%02X:%02X:%02X:%02X:%02X\r\n",
+              g_net_info.mac[0], g_net_info.mac[1], g_net_info.mac[2],
+              g_net_info.mac[3], g_net_info.mac[4], g_net_info.mac[5]);
+    W5500_DBG("[W5500] IP %u.%u.%u.%u\r\n",
+              g_net_info.ip[0], g_net_info.ip[1], g_net_info.ip[2], g_net_info.ip[3]);
+    W5500_DBG("[W5500] SN %u.%u.%u.%u\r\n",
+              g_net_info.sn[0], g_net_info.sn[1], g_net_info.sn[2], g_net_info.sn[3]);
+    W5500_DBG("[W5500] GW %u.%u.%u.%u\r\n",
+              g_net_info.gw[0], g_net_info.gw[1], g_net_info.gw[2], g_net_info.gw[3]);
+    W5500_DBG("[W5500] DNS %u.%u.%u.%u\r\n",
+              g_net_info.dns[0], g_net_info.dns[1], g_net_info.dns[2], g_net_info.dns[3]);
+}
+
+static void update_phy_link_cache(void)
+{
+    uint8_t phy_link = PHY_LINK_OFF;
+
+    if (g_initialized && ctlwizchip(CW_GET_PHYLINK, (void *)&phy_link) == 0) {
+        g_phy_link = phy_link;
+    }
+    else {
+        g_phy_link = PHY_LINK_OFF;
+    }
+}
+
+static void dbg_log_assigned_ip(const char *reason)
+{
+    W5500_DBG("%s assigned IP=%u.%u.%u.%u GW=%u.%u.%u.%u SN=%u.%u.%u.%u DNS=%u.%u.%u.%u",
+              reason,
+              g_net_info.ip[0], g_net_info.ip[1], g_net_info.ip[2], g_net_info.ip[3],
+              g_net_info.gw[0], g_net_info.gw[1], g_net_info.gw[2], g_net_info.gw[3],
+              g_net_info.sn[0], g_net_info.sn[1], g_net_info.sn[2], g_net_info.sn[3],
+              g_net_info.dns[0], g_net_info.dns[1], g_net_info.dns[2], g_net_info.dns[3]);
+}
+
+static void apply_dhcp_lease(void)
+{
+    getIPfromDHCP(g_net_info.ip);
+    getGWfromDHCP(g_net_info.gw);
+    getSNfromDHCP(g_net_info.sn);
+    getDNSfromDHCP(g_net_info.dns);
+    g_net_info.dhcp = NETINFO_DHCP;
+
+    ctlnetwork(CN_SET_NETINFO, (void *)&g_net_info);
+
+    g_has_lease = true;
+    W5500_DBG("[W5500] DHCP lease acquired\r\n");
+    dbg_log_assigned_ip("DHCP");
+    log_net_info();
+}
+
+static void on_dhcp_assign(void)
+{
+    apply_dhcp_lease();
+}
+
+static void on_dhcp_update(void)
+{
+    W5500_DBG("[W5500] DHCP lease updated\r\n");
+    apply_dhcp_lease();
+}
+
+static void on_dhcp_conflict(void)
+{
+    g_has_lease = false;
+    W5500_DBG("[W5500] DHCP conflict detected\r\n");
+}
+
+static inline void wizchip_select(void)
+{
+    gpio_put(W5500_PIN_CS, 0);
+}
+
+static inline void wizchip_deselect(void)
+{
+    gpio_put(W5500_PIN_CS, 1);
+}
+
+static uint8_t wizchip_read(void)
+{
+    uint8_t tx = 0xFF;
+    uint8_t rx = 0x00;
+    spi_write_read_blocking(W5500_SPI_PORT, &tx, &rx, 1);
+    return rx;
+}
+
+static void wizchip_write(uint8_t tx_data)
+{
+    spi_write_blocking(W5500_SPI_PORT, &tx_data, 1);
+}
+
+static void wizchip_read_burst(uint8_t *buffer, uint16_t len)
+{
+    uint8_t tx = 0xFF;
+    spi_read_blocking(W5500_SPI_PORT, tx, buffer, len);
+}
+
+static void wizchip_write_burst(uint8_t *buffer, uint16_t len)
+{
+    spi_write_blocking(W5500_SPI_PORT, buffer, len);
+}
+
+static void wizchip_critical_enter(void)
+{
+    g_irq_state = save_and_disable_interrupts();
+}
+
+static void wizchip_critical_exit(void)
+{
+    restore_interrupts(g_irq_state);
+}
+
+static void w5500_spi_init(void)
+{
+    spi_init(W5500_SPI_PORT, W5500_SPI_BAUDRATE_HZ);
+
+    gpio_set_function(W5500_PIN_SCK, GPIO_FUNC_SPI);
+    gpio_set_function(W5500_PIN_MOSI, GPIO_FUNC_SPI);
+    gpio_set_function(W5500_PIN_MISO, GPIO_FUNC_SPI);
+
+    gpio_init(W5500_PIN_CS);
+    gpio_set_dir(W5500_PIN_CS, GPIO_OUT);
+    gpio_put(W5500_PIN_CS, 1);
+
+    gpio_init(W5500_PIN_INT);
+    gpio_set_dir(W5500_PIN_INT, GPIO_IN);
+    gpio_pull_up(W5500_PIN_INT);
+
+    W5500_DBG("SPI initialized port=spi0 baud=%u SCK=%u MOSI=%u MISO=%u CS=%u INT=%u",
+              (unsigned)W5500_SPI_BAUDRATE_HZ,
+              (unsigned)W5500_PIN_SCK,
+              (unsigned)W5500_PIN_MOSI,
+              (unsigned)W5500_PIN_MISO,
+              (unsigned)W5500_PIN_CS,
+              (unsigned)W5500_PIN_INT);
+}
+
+static void w5500_reset(void)
+{
+    gpio_init(W5500_PIN_RST);
+    gpio_set_dir(W5500_PIN_RST, GPIO_OUT);
+
+    gpio_put(W5500_PIN_RST, 0);
+    sleep_ms(100);
+    gpio_put(W5500_PIN_RST, 1);
+    sleep_ms(100);
+
+    W5500_DBG("Reset toggled on RST=%u", (unsigned)W5500_PIN_RST);
+}
+
+static bool w5500_check_version(void)
+{
+    uint8_t version = getVERSIONR();
+    if (version != 0x04) {
+        W5500_DBG("[W5500] version mismatch: 0x%02X\r\n", version);
+        return false;
+    }
+
+    W5500_DBG("[W5500] version OK: 0x%02X\r\n", version);
+    return true;
+}
+
+static bool w5500_hw_init(void)
+{
+    uint8_t memsize[2][8] = {
+        {2, 2, 2, 2, 2, 2, 2, 2},
+        {2, 2, 2, 2, 2, 2, 2, 2},
+    };
+
+    w5500_spi_init();
+
+    reg_wizchip_cris_cbfunc(wizchip_critical_enter, wizchip_critical_exit);
+    reg_wizchip_cs_cbfunc(wizchip_select, wizchip_deselect);
+    reg_wizchip_spi_cbfunc(wizchip_read, wizchip_write);
+    reg_wizchip_spiburst_cbfunc(wizchip_read_burst, wizchip_write_burst);
+
+    w5500_reset();
+
+    if (ctlwizchip(CW_INIT_WIZCHIP, (void *)memsize) == -1) {
+        W5500_DBG("[W5500] CW_INIT_WIZCHIP failed\r\n");
+        return false;
+    }
+
+    W5500_DBG("WIZCHIP memory initialized (8 sockets, TX/RX 2KB each)");
+
+    if (!w5500_check_version()) {
+        return false;
+    }
+
+    return true;
+}
+
+static void init_mac_address(void)
+{
+    pico_unique_board_id_t id;
+    pico_get_unique_board_id(&id);
+
+    g_net_info.mac[0] = 0x00;   
+    g_net_info.mac[1] = 0x08;   
+    g_net_info.mac[2] = 0xDC;  
+    g_net_info.mac[3] = id.id[4];
+    g_net_info.mac[4] = id.id[5];
+    g_net_info.mac[5] = id.id[6];
+}
+
+bool ei_w5500_ethernet_init(void)
+{
+    if (g_initialized) {
+        return false;
+    }
+
+    init_mac_address();
+    W5500_DBG("Generated MAC %02X:%02X:%02X:%02X:%02X:%02X",
+              g_net_info.mac[0], g_net_info.mac[1], g_net_info.mac[2],
+              g_net_info.mac[3], g_net_info.mac[4], g_net_info.mac[5]);
+
+    if (!w5500_hw_init()) {
+        return false;
+    }
+
+    ctlnetwork(CN_SET_NETINFO, (void *)&g_net_info);
+
+    W5500_DBG("Post-init netinfo IP=%u.%u.%u.%u (expected 0.0.0.0 before DHCP lease)",
+              g_net_info.ip[0], g_net_info.ip[1], g_net_info.ip[2], g_net_info.ip[3]);
+
+    DHCP_init(DHCP_SOCKET_IDX, g_dhcp_buffer);
+    reg_dhcp_cbfunc(on_dhcp_assign, on_dhcp_update, on_dhcp_conflict);
+
+    g_initialized = true;
+    g_last_dhcp_tick_ms = now_ms();
+    g_last_dhcp_poll_ms = g_last_dhcp_tick_ms;
+    g_last_dhcp_fail_log_ms = g_last_dhcp_tick_ms;
+    g_last_phy_log_ms = g_last_dhcp_tick_ms;
+    update_phy_link_cache();
+
+    W5500_DBG("[W5500] Ethernet init complete, starting DHCP\r\n");
+
+    return true;
+}
+
+bool ei_w5500_ethernet_get_netinfo(ei_w5500_ethernet_netinfo_t *netinfo)
+{
+    if (netinfo == nullptr) {
+        return false;
+    }
+
+    uint32_t irq_state = save_and_disable_interrupts();
+
+    memset(netinfo, 0, sizeof(*netinfo));
+    netinfo->initialized = g_initialized;
+    netinfo->dhcp_leased = g_has_lease;
+    netinfo->phy_link = g_phy_link;
+
+    if (g_initialized) {
+        memcpy(netinfo->mac, g_net_info.mac, sizeof(netinfo->mac));
+        memcpy(netinfo->ip, g_net_info.ip, sizeof(netinfo->ip));
+        memcpy(netinfo->sn, g_net_info.sn, sizeof(netinfo->sn));
+        memcpy(netinfo->gw, g_net_info.gw, sizeof(netinfo->gw));
+        memcpy(netinfo->dns, g_net_info.dns, sizeof(netinfo->dns));
+    }
+
+    restore_interrupts(irq_state);
+
+    return true;
+}
+
+void ei_w5500_ethernet_poll(void)
+{
+    if (!g_initialized) {
+        return;
+    }
+
+    const uint32_t now = now_ms();
+
+    while ((now - g_last_dhcp_tick_ms) >= 1000) {
+        DHCP_time_handler();
+        g_last_dhcp_tick_ms += 1000;
+    }
+
+    if ((now - g_last_dhcp_poll_ms) < DHCP_POLL_INTERVAL_MS) {
+        return;
+    }
+    g_last_dhcp_poll_ms = now;
+
+    uint8_t dhcp_state = DHCP_run();
+
+    if (dhcp_state != g_last_dhcp_state) {
+        W5500_DBG("DHCP state changed: %s (%u)", dhcp_state_to_str(dhcp_state), (unsigned)dhcp_state);
+        g_last_dhcp_state = dhcp_state;
+    }
+
+    if ((now - g_last_phy_log_ms) >= PHY_LOG_INTERVAL_MS) {
+        update_phy_link_cache();
+        W5500_DBG("PHY link: %s", (g_phy_link == PHY_LINK_ON) ? "UP" : "DOWN");
+        g_last_phy_log_ms = now;
+    }
+
+    if (dhcp_state == DHCP_IP_LEASED) {
+        if (!g_has_lease) {
+            apply_dhcp_lease();
+        }
+    }
+    else if (dhcp_state == DHCP_FAILED) {
+        g_has_lease = false;
+        if ((now - g_last_dhcp_fail_log_ms) >= DHCP_LOG_RETRY_INTERVAL_MS) {
+            W5500_DBG("[W5500] DHCP not acquired yet, retrying in background\r\n");
+            g_last_dhcp_fail_log_ms = now;
+        }
+    }
+}
+
+#else
+
+void ei_w5500_ethernet_init(void)
+{
+}
+
+void ei_w5500_ethernet_poll(void)
+{
+}
+
+bool ei_w5500_ethernet_get_netinfo(ei_w5500_ethernet_netinfo_t *netinfo)
+{
+    (void)netinfo;
+    return false;
+}
+
+#endif

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_ethernet.h
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_ethernet.h
@@ -1,0 +1,33 @@
+#ifndef EI_W5500_ETHERNET_H_
+#define EI_W5500_ETHERNET_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EI_W5500_PHY_LINK_OFF             0     ///< Link Off
+#define EI_W5500_PHY_LINK_ON              1     ///< Link On
+
+typedef struct {
+	bool initialized;
+	bool dhcp_leased;
+	uint8_t phy_link;
+	uint8_t mac[6];
+	uint8_t ip[4];
+	uint8_t sn[4];
+	uint8_t gw[4];
+	uint8_t dns[4];
+} ei_w5500_ethernet_netinfo_t;
+
+bool ei_w5500_ethernet_init(void);
+void ei_w5500_ethernet_poll(void);
+bool ei_w5500_ethernet_get_netinfo(ei_w5500_ethernet_netinfo_t *netinfo);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EI_W5500_ETHERNET_H_

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_mqtt.cpp
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_mqtt.cpp
@@ -1,0 +1,255 @@
+#include "ei_w5500_mqtt.h"
+
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+
+#include "ei_classifier_porting.h"
+#include "ei_w5500_ethernet.h"
+#include "mqtt/MQTTClient.h"
+#include "mqtt/mqtt_interface.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef EI_MQTT_BROKER_HOST
+#define EI_MQTT_BROKER_HOST "192.168.11.100"
+#endif
+
+#ifndef EI_MQTT_BROKER_PORT
+#define EI_MQTT_BROKER_PORT 1883
+#endif
+
+#ifndef EI_MQTT_CLIENT_ID
+#define EI_MQTT_CLIENT_ID "edge-impulse-w5500"
+#endif
+
+#ifndef EI_MQTT_TOPIC
+#define EI_MQTT_TOPIC "edgeimpulse/result"
+#endif
+
+#ifndef EI_MQTT_SOCKET
+#define EI_MQTT_SOCKET 1
+#endif
+
+#ifndef EI_MQTT_KEEPALIVE_SEC
+#define EI_MQTT_KEEPALIVE_SEC 30
+#endif
+
+static bool g_mqtt_initialized = false;
+static uint8_t g_broker_ip[4] = {0};
+
+static Network g_mqtt_network;
+static MQTTClient g_mqtt_client;
+static unsigned char g_mqtt_send_buf[256];
+static unsigned char g_mqtt_read_buf[256];
+
+static bool parse_ipv4(const char *host, uint8_t out_ip[4])
+{
+    unsigned long parts[4] = {0, 0, 0, 0};
+    const char *cursor = host;
+    char *end_ptr = nullptr;
+
+    if (host == nullptr || out_ip == nullptr) {
+        return false;
+    }
+
+    for (int i = 0; i < 4; i++) {
+        parts[i] = strtoul(cursor, &end_ptr, 10);
+        if (end_ptr == cursor || parts[i] > 255UL) {
+            return false;
+        }
+
+        if (i < 3) {
+            if (*end_ptr != '.') {
+                return false;
+            }
+            cursor = end_ptr + 1;
+        }
+        else {
+            if (*end_ptr != '\0') {
+                return false;
+            }
+        }
+    }
+
+    for (int i = 0; i < 4; i++) {
+        out_ip[i] = (uint8_t)parts[i];
+    }
+
+    return true;
+}
+
+static bool is_network_ready(void)
+{
+    ei_w5500_ethernet_netinfo_t netinfo;
+
+    if (!ei_w5500_ethernet_get_netinfo(&netinfo)) {
+        return false;
+    }
+
+    if (!netinfo.initialized || !netinfo.dhcp_leased) {
+        return false;
+    }
+
+    return (netinfo.phy_link == EI_W5500_PHY_LINK_ON);
+}
+
+bool ei_w5500_mqtt_init(void)
+{
+    if (g_mqtt_initialized) {
+        return true;
+    }
+
+    if (!parse_ipv4(EI_MQTT_BROKER_HOST, g_broker_ip)) {
+        ei_printf("[MQTT] Invalid broker IPv4: %s\r\n", EI_MQTT_BROKER_HOST);
+        return false;
+    }
+
+    mqtt_network_init(&g_mqtt_network, EI_MQTT_SOCKET);
+    MQTTClientInit(&g_mqtt_client,
+                   &g_mqtt_network,
+                   g_mqtt_send_buf,
+                   sizeof(g_mqtt_send_buf),
+                   g_mqtt_read_buf,
+                   sizeof(g_mqtt_read_buf));
+
+    g_mqtt_initialized = true;
+    return true;
+}
+
+bool ei_w5500_mqtt_is_connected(void)
+{
+    if (!g_mqtt_initialized) {
+        return false;
+    }
+
+    return MQTTIsConnected(&g_mqtt_client) != 0;
+}
+
+bool ei_w5500_mqtt_connect(void)
+{
+    MQTTPacket_connectData connect_data = MQTTPacket_connectData_initializer;
+
+    if (!ei_w5500_mqtt_init()) {
+        return false;
+    }
+
+    if (!is_network_ready()) {
+        return false;
+    }
+
+    if (ei_w5500_mqtt_is_connected()) {
+        return true;
+    }
+
+    if (mqtt_network_connect(&g_mqtt_network, g_broker_ip, EI_MQTT_BROKER_PORT) != 0) {
+        return false;
+    }
+
+    connect_data.clientID.cstring = EI_MQTT_CLIENT_ID;
+    connect_data.keepAliveInterval = EI_MQTT_KEEPALIVE_SEC;
+    connect_data.cleansession = 1;
+
+    if (MQTTConnect(&g_mqtt_client, &connect_data) != 0) {
+        mqtt_network_disconnect(&g_mqtt_network);
+        return false;
+    }
+
+    return true;
+}
+
+bool ei_w5500_mqtt_yield(void)
+{
+    if (!g_mqtt_initialized || !ei_w5500_mqtt_is_connected()) {
+        return false;
+    }
+
+    if (MQTTYield(&g_mqtt_client, 1) != 0) {
+        (void)MQTTDisconnect(&g_mqtt_client);
+        return false;
+    }
+
+    return true;
+}
+
+bool ei_w5500_mqtt_publish_result(const ei_impulse_result_t *result)
+{
+    const char *best_label = nullptr;
+    float best_score = 0.0f;
+    char payload[128];
+    MQTTMessage message;
+
+    if (result == nullptr) {
+        return false;
+    }
+
+    if (!ei_w5500_mqtt_connect()) {
+        return false;
+    }
+
+    // TODO: Add object detection MQTT payload publishing when OD transport format is defined.
+    if (result->bounding_boxes_count > 0) {
+        return false;
+    }
+
+    for (size_t ix = 0; ix < EI_CLASSIFIER_LABEL_COUNT; ix++) {
+        const float score = result->classification[ix].value;
+        if (best_label == nullptr || score > best_score) {
+            best_score = score;
+            best_label = result->classification[ix].label;
+        }
+    }
+
+    if (best_label == nullptr) {
+        return false;
+    }
+
+    (void)snprintf(payload,
+                   sizeof(payload),
+                   "{\"label\":\"%s\",\"score\":%.5f}",
+                   best_label,
+                   (double)best_score);
+
+    memset(&message, 0, sizeof(message));
+    message.qos = 0;
+    message.retained = 0;
+    message.payload = payload;
+    message.payloadlen = (int)strlen(payload);
+
+    if (MQTTPublish(&g_mqtt_client, EI_MQTT_TOPIC, &message) != 0) {
+        (void)MQTTDisconnect(&g_mqtt_client);
+        return false;
+    }
+
+    return true;
+}
+
+#else
+
+bool ei_w5500_mqtt_init(void)
+{
+    return false;
+}
+
+bool ei_w5500_mqtt_is_connected(void)
+{
+    return false;
+}
+
+bool ei_w5500_mqtt_connect(void)
+{
+    return false;
+}
+
+bool ei_w5500_mqtt_yield(void)
+{
+    return false;
+}
+
+bool ei_w5500_mqtt_publish_result(const ei_impulse_result_t *result)
+{
+    (void)result;
+    return false;
+}
+
+#endif

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_mqtt.h
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/ei_w5500_mqtt.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "edge-impulse-sdk/classifier/ei_classifier_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool ei_w5500_mqtt_init(void);
+bool ei_w5500_mqtt_is_connected(void);
+bool ei_w5500_mqtt_connect(void);
+bool ei_w5500_mqtt_yield(void);
+bool ei_w5500_mqtt_publish_result(const ei_impulse_result_t *result);
+
+#ifdef __cplusplus
+}
+#endif

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/MQTTClient.c
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/MQTTClient.c
@@ -1,0 +1,258 @@
+#include "MQTTClient.h"
+
+#include "pico/time.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define MQTT_PKT_CONNECT 0x10
+#define MQTT_PKT_CONNACK 0x20
+#define MQTT_PKT_PUBLISH 0x30
+#define MQTT_PKT_PINGREQ 0xC0
+#define MQTT_PKT_PINGRESP 0xD0
+#define MQTT_PKT_DISCONNECT 0xE0
+
+static uint32_t now_ms(void)
+{
+    return to_ms_since_boot(get_absolute_time());
+}
+
+static int mqtt_write_remaining_length(unsigned char *buf, int len)
+{
+    int i = 0;
+
+    do {
+        unsigned char encoded = (unsigned char)(len % 128);
+        len /= 128;
+        if (len > 0) {
+            encoded |= 0x80;
+        }
+        buf[i++] = encoded;
+    } while (len > 0 && i < 4);
+
+    return i;
+}
+
+static int mqtt_encode_string(unsigned char *buf, int buf_len, const char *s)
+{
+    int slen;
+
+    if (s == NULL || buf_len < 2) {
+        return -1;
+    }
+
+    slen = (int)strlen(s);
+    if ((slen + 2) > buf_len) {
+        return -1;
+    }
+
+    buf[0] = (unsigned char)((slen >> 8) & 0xFF);
+    buf[1] = (unsigned char)(slen & 0xFF);
+    memcpy(&buf[2], s, (size_t)slen);
+
+    return slen + 2;
+}
+
+void MQTTClientInit(MQTTClient *c,
+                    Network *network,
+                    unsigned char *sendbuf,
+                    int sendbuf_size,
+                    unsigned char *readbuf,
+                    int readbuf_size)
+{
+    if (c == NULL) {
+        return;
+    }
+
+    c->ipstack = network;
+    c->sendbuf = sendbuf;
+    c->sendbuf_size = sendbuf_size;
+    c->readbuf = readbuf;
+    c->readbuf_size = readbuf_size;
+    c->keepAliveInterval = 60;
+    c->last_tx_ms = now_ms();
+    c->isconnected = 0;
+}
+
+int MQTTConnect(MQTTClient *c, MQTTPacket_connectData *options)
+{
+    int rc;
+    int offset;
+    int rem_len;
+    int fh_len;
+    int vh_len;
+    int payload_len;
+    int client_id_len;
+    int total_len;
+    unsigned char connect_flags;
+
+    if (c == NULL || c->ipstack == NULL || options == NULL || options->clientID.cstring == NULL) {
+        return -1;
+    }
+
+    client_id_len = (int)strlen(options->clientID.cstring);
+    vh_len = 10;
+    payload_len = 2 + client_id_len;
+    rem_len = vh_len + payload_len;
+
+    offset = 0;
+    c->sendbuf[offset++] = MQTT_PKT_CONNECT;
+    fh_len = mqtt_write_remaining_length(&c->sendbuf[offset], rem_len);
+    offset += fh_len;
+
+    c->sendbuf[offset++] = 0x00;
+    c->sendbuf[offset++] = 0x04;
+    c->sendbuf[offset++] = 'M';
+    c->sendbuf[offset++] = 'Q';
+    c->sendbuf[offset++] = 'T';
+    c->sendbuf[offset++] = 'T';
+    c->sendbuf[offset++] = options->MQTTVersion;
+
+    connect_flags = 0;
+    if (options->cleansession) {
+        connect_flags |= 0x02;
+    }
+    c->sendbuf[offset++] = connect_flags;
+
+    c->sendbuf[offset++] = (unsigned char)((options->keepAliveInterval >> 8) & 0xFF);
+    c->sendbuf[offset++] = (unsigned char)(options->keepAliveInterval & 0xFF);
+
+    rc = mqtt_encode_string(&c->sendbuf[offset], c->sendbuf_size - offset, options->clientID.cstring);
+    if (rc < 0) {
+        return -1;
+    }
+    offset += rc;
+
+    total_len = offset;
+    rc = mqtt_network_write(c->ipstack, c->sendbuf, total_len, 1000);
+    if (rc != total_len) {
+        return -1;
+    }
+
+    rc = mqtt_network_read(c->ipstack, c->readbuf, c->readbuf_size, 1500);
+    if (rc < 4) {
+        return -1;
+    }
+
+    if (c->readbuf[0] != MQTT_PKT_CONNACK || c->readbuf[1] != 0x02 || c->readbuf[3] != 0x00) {
+        return -1;
+    }
+
+    c->keepAliveInterval = options->keepAliveInterval;
+    c->last_tx_ms = now_ms();
+    c->isconnected = 1;
+
+    return 0;
+}
+
+int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message)
+{
+    int topic_len;
+    int rem_len;
+    int offset;
+    int fh_len;
+    int total_len;
+    int rc;
+
+    if (c == NULL || c->ipstack == NULL || topicName == NULL || message == NULL || message->payload == NULL) {
+        return -1;
+    }
+
+    if (!c->isconnected) {
+        return -1;
+    }
+
+    topic_len = (int)strlen(topicName);
+    rem_len = 2 + topic_len + message->payloadlen;
+
+    offset = 0;
+    c->sendbuf[offset++] = (unsigned char)(MQTT_PKT_PUBLISH | ((message->qos & 0x03) << 1) | (message->retained ? 0x01 : 0x00));
+    fh_len = mqtt_write_remaining_length(&c->sendbuf[offset], rem_len);
+    offset += fh_len;
+
+    rc = mqtt_encode_string(&c->sendbuf[offset], c->sendbuf_size - offset, topicName);
+    if (rc < 0) {
+        return -1;
+    }
+    offset += rc;
+
+    if ((offset + message->payloadlen) > c->sendbuf_size) {
+        return -1;
+    }
+
+    memcpy(&c->sendbuf[offset], message->payload, (size_t)message->payloadlen);
+    offset += message->payloadlen;
+    total_len = offset;
+
+    rc = mqtt_network_write(c->ipstack, c->sendbuf, total_len, 1000);
+    if (rc != total_len) {
+        c->isconnected = 0;
+        return -1;
+    }
+
+    c->last_tx_ms = now_ms();
+    return 0;
+}
+
+int MQTTYield(MQTTClient *c, int timeout_ms)
+{
+    uint32_t now;
+    int rc;
+
+    if (c == NULL || c->ipstack == NULL || !c->isconnected) {
+        return -1;
+    }
+
+    now = now_ms();
+    if (c->keepAliveInterval > 0 && (now - c->last_tx_ms) >= ((uint32_t)c->keepAliveInterval * 1000U)) {
+        c->sendbuf[0] = MQTT_PKT_PINGREQ;
+        c->sendbuf[1] = 0x00;
+
+        rc = mqtt_network_write(c->ipstack, c->sendbuf, 2, 500);
+        if (rc != 2) {
+            c->isconnected = 0;
+            return -1;
+        }
+
+        c->last_tx_ms = now_ms();
+    }
+
+    rc = mqtt_network_read(c->ipstack, c->readbuf, c->readbuf_size, timeout_ms);
+    if (rc < 0) {
+        c->isconnected = 0;
+        return -1;
+    }
+
+    if (rc >= 2 && c->readbuf[0] == MQTT_PKT_PINGRESP && c->readbuf[1] == 0x00) {
+        return 0;
+    }
+
+    return 0;
+}
+
+int MQTTDisconnect(MQTTClient *c)
+{
+    if (c == NULL || c->ipstack == NULL) {
+        return -1;
+    }
+
+    if (c->isconnected) {
+        c->sendbuf[0] = MQTT_PKT_DISCONNECT;
+        c->sendbuf[1] = 0x00;
+        (void)mqtt_network_write(c->ipstack, c->sendbuf, 2, 200);
+    }
+
+    mqtt_network_disconnect(c->ipstack);
+    c->isconnected = 0;
+
+    return 0;
+}
+
+int MQTTIsConnected(MQTTClient *c)
+{
+    if (c == NULL) {
+        return 0;
+    }
+
+    return c->isconnected ? 1 : 0;
+}

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/MQTTClient.h
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/MQTTClient.h
@@ -1,0 +1,59 @@
+#ifndef EI_W5500_MQTT_CLIENT_H_
+#define EI_W5500_MQTT_CLIENT_H_
+
+#include <stdint.h>
+
+#include "mqtt_interface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *cstring;
+} MQTTString;
+
+typedef struct {
+    unsigned char qos;
+    unsigned char retained;
+    const void *payload;
+    int payloadlen;
+} MQTTMessage;
+
+typedef struct {
+    unsigned char MQTTVersion;
+    unsigned short keepAliveInterval;
+    unsigned char cleansession;
+    MQTTString clientID;
+} MQTTPacket_connectData;
+
+typedef struct {
+    Network *ipstack;
+    unsigned char *sendbuf;
+    int sendbuf_size;
+    unsigned char *readbuf;
+    int readbuf_size;
+    unsigned short keepAliveInterval;
+    uint32_t last_tx_ms;
+    unsigned char isconnected;
+} MQTTClient;
+
+#define MQTTPacket_connectData_initializer { 4, 60, 1, { 0 } }
+
+void MQTTClientInit(MQTTClient *c,
+                    Network *network,
+                    unsigned char *sendbuf,
+                    int sendbuf_size,
+                    unsigned char *readbuf,
+                    int readbuf_size);
+int MQTTConnect(MQTTClient *c, MQTTPacket_connectData *options);
+int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message);
+int MQTTYield(MQTTClient *c, int timeout_ms);
+int MQTTDisconnect(MQTTClient *c);
+int MQTTIsConnected(MQTTClient *c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/mqtt_interface.c
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/mqtt_interface.c
@@ -1,0 +1,132 @@
+#include "mqtt_interface.h"
+
+#include "pico/stdlib.h"
+
+#include "socket.h"
+#include "wizchip_conf.h"
+
+static int is_socket_established(uint8_t sn)
+{
+    return getSn_SR(sn) == SOCK_ESTABLISHED;
+}
+
+void mqtt_network_init(Network *n, uint8_t socket_no)
+{
+    if (n == 0) {
+        return;
+    }
+
+    n->socket = socket_no;
+    n->connected = 0;
+}
+
+int mqtt_network_connect(Network *n, const uint8_t *addr, uint16_t port)
+{
+    int32_t rc;
+    uint32_t start_ms;
+
+    if (n == 0 || addr == 0) {
+        return -1;
+    }
+
+    close(n->socket);
+
+    rc = socket(n->socket, Sn_MR_TCP, 0, 0);
+    if (rc < 0) {
+        return -1;
+    }
+
+    rc = connect(n->socket, (uint8_t *)addr, port);
+    if (rc < 0) {
+        close(n->socket);
+        return -1;
+    }
+
+    start_ms = to_ms_since_boot(get_absolute_time());
+    while ((to_ms_since_boot(get_absolute_time()) - start_ms) < 3000U) {
+        if (is_socket_established(n->socket)) {
+            n->connected = 1;
+            return 0;
+        }
+        sleep_ms(2);
+    }
+
+    close(n->socket);
+    n->connected = 0;
+    return -1;
+}
+
+int mqtt_network_read(Network *n, unsigned char *buffer, int len, int timeout_ms)
+{
+    uint32_t start_ms;
+    uint16_t available;
+    int32_t rc;
+
+    if (n == 0 || buffer == 0 || len <= 0 || n->connected == 0) {
+        return -1;
+    }
+
+    start_ms = to_ms_since_boot(get_absolute_time());
+    while ((to_ms_since_boot(get_absolute_time()) - start_ms) < (uint32_t)timeout_ms) {
+        if (!is_socket_established(n->socket)) {
+            n->connected = 0;
+            return -1;
+        }
+
+        available = getSn_RX_RSR(n->socket);
+        if (available > 0) {
+            int32_t to_read = (available > (uint16_t)len) ? (int32_t)len : (int32_t)available;
+            rc = recv(n->socket, buffer, to_read);
+            return (rc < 0) ? -1 : (int)rc;
+        }
+
+        sleep_ms(2);
+    }
+
+    return 0;
+}
+
+int mqtt_network_write(Network *n, const unsigned char *buffer, int len, int timeout_ms)
+{
+    uint32_t start_ms;
+    int32_t rc;
+
+    (void)timeout_ms;
+
+    if (n == 0 || buffer == 0 || len <= 0 || n->connected == 0) {
+        return -1;
+    }
+
+    start_ms = to_ms_since_boot(get_absolute_time());
+    while ((to_ms_since_boot(get_absolute_time()) - start_ms) < 3000U) {
+        if (!is_socket_established(n->socket)) {
+            n->connected = 0;
+            return -1;
+        }
+
+        rc = send(n->socket, (uint8_t *)buffer, (uint16_t)len);
+        if (rc > 0) {
+            return (int)rc;
+        }
+
+        if (rc < 0) {
+            n->connected = 0;
+            return -1;
+        }
+
+        sleep_ms(2);
+    }
+
+    return -1;
+}
+
+void mqtt_network_disconnect(Network *n)
+{
+    if (n == 0) {
+        return;
+    }
+
+    disconnect(n->socket);
+    close(n->socket);
+    n->connected = 0;
+}

--- a/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/mqtt_interface.h
+++ b/edge-impulse/ingestion-sdk-platform/wiznet-w5x00_evb_pico/mqtt/mqtt_interface.h
@@ -1,0 +1,25 @@
+#ifndef EI_W5500_MQTT_INTERFACE_H_
+#define EI_W5500_MQTT_INTERFACE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t socket;
+    uint8_t connected;
+} Network;
+
+void mqtt_network_init(Network *n, uint8_t socket_no);
+int mqtt_network_connect(Network *n, const uint8_t *addr, uint16_t port);
+int mqtt_network_read(Network *n, unsigned char *buffer, int len, int timeout_ms);
+int mqtt_network_write(Network *n, const unsigned char *buffer, int len, int timeout_ms);
+void mqtt_network_disconnect(Network *n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/firmware-sdk/at-server/ei_at_command_set.h
+++ b/firmware-sdk/at-server/ei_at_command_set.h
@@ -126,6 +126,8 @@
 #define AT_BOOTMODE_HELP_TEXT       "Jump to bootloader"
 #define AT_INFO                     "INFO"
 #define AT_INFO_HELP_TEXT           "Prints details about compiled firmware and ML model"
+#define AT_NETINFO                  "NETINFO"
+#define AT_NETINFO_HELP_TEXT        "Print W5500 Ethernet information"
 
 /*************************************************************************************************/
 /* HELP is not necessary as it is built-in into ATServer and

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,10 @@
 #include "ei_rp2xxx_internal_temperature.h"
 #include "ei_run_impulse.h"
 #include "ei_ultrasonicsensor.h"
+#include "ei_w5500_ethernet.h"
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+#include "ei_w5500_mqtt.h"
+#endif
 #include "pico/multicore.h"
 #include "pico/stdlib.h"
 #include "task.h"
@@ -56,12 +60,25 @@
 
 EiDeviceInfo *EiDevInfo = dynamic_cast<EiDeviceInfo *>(EiDeviceRP2xxx::get_device());
 static ATServer *at;
+static TaskHandle_t ei_serial_task_handle = nullptr;
+
+#if defined(EI_W5500_ETHERNET)
+static TaskHandle_t ei_ethernet_task_handle = nullptr;
+#endif
+
+static constexpr uint16_t EI_SERIAL_TASK_STACK = 2048;
+static constexpr UBaseType_t EI_SERIAL_TASK_PRIO = tskIDLE_PRIORITY + 2;
+
+#if defined(EI_W5500_ETHERNET)
+static constexpr uint16_t EI_ETHERNET_TASK_STACK = 2048;
+static constexpr UBaseType_t EI_ETHERNET_TASK_PRIO = tskIDLE_PRIORITY + 1;
+#endif
 
 void ei_init(void)
 {
     EiDeviceRP2xxx *dev = static_cast<EiDeviceRP2xxx *>(EiDeviceRP2xxx::get_device());
 
-    ei_sleep(2000); // Wait for the serial port to be ready
+    ei_sleep(3000); // Wait for the serial port to be ready
 
     ei_printf(
         "Hello from Edge Impulse\r\n"
@@ -74,7 +91,7 @@ void ei_init(void)
 
     // Setup ADXL345 Accelerometer
     if (ei_accelerometer_init() == false) {
-        ei_printf("ADXL345 initialization failed");
+        ei_printf("ADXL345 initialization failed\r\n");
     }
 
     // Setup the inertial sensor
@@ -87,7 +104,7 @@ void ei_init(void)
         ei_printf("DHT11 initialization failed\r\n");
     }
     else {
-        ei_printf("DHT11 initialization successful");
+        ei_printf("DHT11 initialization successful\r\n");
     }
 
     // Setup the ultrasonic sensor
@@ -110,22 +127,53 @@ void ei_init(void)
     at->print_prompt();
 }
 
-void ei_main(void *pvParameters)
+void ei_serial_task(void *pvParameters)
 {
     /* Initialize Edge Impulse sensors and commands */
     ei_init();
 
+#if defined(EI_W5500_ETHERNET)
+    if (ei_ethernet_task_handle != nullptr) {
+        xTaskNotifyGive(ei_ethernet_task_handle);
+    }
+#endif
+
     while (true) {
         /* handle command comming from uart */
-        ei_sleep(5);
         char data = ei_get_serial_byte();
 
-        while (data != 0xFF) {
+        while (data != (char)0xFF) {
             at->handle(data);
             data = ei_get_serial_byte();
         }
+
+        vTaskDelay(pdMS_TO_TICKS(5));
     }
 }
+
+#if defined(EI_W5500_ETHERNET)
+void ei_ethernet_task(void *pvParameters)
+{
+    if (ulTaskNotifyTake(pdTRUE, portMAX_DELAY) == 0) {
+        return;
+    }
+
+    if(!ei_w5500_ethernet_init())
+    {
+        ei_printf("W5500 ethernet init failed...\r\n");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    while (true) {
+        ei_w5500_ethernet_poll();
+#if defined(EI_W5500_ETHERNET) && defined(EI_MQTT_PUBLISH)
+        (void)ei_w5500_mqtt_yield();
+#endif
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+}
+#endif
 
 /* To verify FreeRTOS is working across both Pico targets */
 void test_task(void *pvParameters)
@@ -138,7 +186,7 @@ void test_task(void *pvParameters)
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0); // Turn LED off
         sleep_ms(1250); // Wait for 1.25 seconds
 
-#elif defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO)
+#elif defined(RASPBERRYPI_PICO2) || defined(RASPBERRYPI_PICO) || defined(WIZNET_W5500_EVB_PICO)
 
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
         sleep_ms(2050);
@@ -174,8 +222,11 @@ int main(void)
         return -1;
     }
 #endif
+    xTaskCreate(ei_serial_task, "ei_serial", EI_SERIAL_TASK_STACK, NULL, EI_SERIAL_TASK_PRIO, &ei_serial_task_handle);
 
-    xTaskCreate(ei_main, "ei_main", 1024, NULL, (tskIDLE_PRIORITY + 1), NULL);
+#if defined(EI_W5500_ETHERNET)
+    xTaskCreate(ei_ethernet_task, "ei_eth", EI_ETHERNET_TASK_STACK, NULL, EI_ETHERNET_TASK_PRIO, &ei_ethernet_task_handle);
+#endif
 
     vTaskStartScheduler();
 

--- a/third_party/ioLibrary_Driver/Ethernet/W5500/w5500.c
+++ b/third_party/ioLibrary_Driver/Ethernet/W5500/w5500.c
@@ -1,0 +1,248 @@
+//*****************************************************************************
+//
+//! \file w5500.c
+//! \brief W5500 HAL Interface.
+//! \version 1.0.2
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2014/05/01> V1.0.2
+//!         1. Implicit type casting -> Explicit type casting. Refer to M20140501
+//!            Fixed the problem on porting into under 32bit MCU
+//!            Issued by Mathias ClauBen, wizwiki forum ID Think01 and bobh
+//!            Thank for your interesting and serious advices.
+//!       <2013/12/20> V1.0.1
+//!         1. Remove warning
+//!         2. WIZCHIP_READ_BUF WIZCHIP_WRITE_BUF in case _WIZCHIP_IO_MODE_SPI_FDM_
+//!            for loop optimized(removed). refer to M20131220
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+//#include <stdio.h>
+#include "w5500.h"
+
+#define _W5500_SPI_VDM_OP_          0x00
+#define _W5500_SPI_FDM_OP_LEN1_     0x01
+#define _W5500_SPI_FDM_OP_LEN2_     0x02
+#define _W5500_SPI_FDM_OP_LEN4_     0x03
+
+#if   (_WIZCHIP_ == 5500)
+////////////////////////////////////////////////////
+
+uint8_t  WIZCHIP_READ(uint32_t AddrSel) {
+    uint8_t ret;
+    uint8_t spi_data[3];
+
+    WIZCHIP_CRITICAL_ENTER();
+    WIZCHIP.CS._select();
+
+    AddrSel |= (_W5500_SPI_READ_ | _W5500_SPI_VDM_OP_);
+
+    if (!WIZCHIP.IF.SPI._read_burst || !WIZCHIP.IF.SPI._write_burst) {	// byte operation
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x00FF0000) >> 16);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x0000FF00) >>  8);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x000000FF) >>  0);
+    } else {															// burst operation
+        spi_data[0] = (AddrSel & 0x00FF0000) >> 16;
+        spi_data[1] = (AddrSel & 0x0000FF00) >> 8;
+        spi_data[2] = (AddrSel & 0x000000FF) >> 0;
+        WIZCHIP.IF.SPI._write_burst(spi_data, 3);
+    }
+    ret = WIZCHIP.IF.SPI._read_byte();
+
+    WIZCHIP.CS._deselect();
+    WIZCHIP_CRITICAL_EXIT();
+    return ret;
+}
+
+void     WIZCHIP_WRITE(uint32_t AddrSel, uint8_t wb) {
+    uint8_t spi_data[4];
+
+    WIZCHIP_CRITICAL_ENTER();
+    WIZCHIP.CS._select();
+
+    AddrSel |= (_W5500_SPI_WRITE_ | _W5500_SPI_VDM_OP_);
+
+    //if(!WIZCHIP.IF.SPI._read_burst || !WIZCHIP.IF.SPI._write_burst) 	// byte operation
+    if (!WIZCHIP.IF.SPI._write_burst) {	// byte operation
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x00FF0000) >> 16);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x0000FF00) >>  8);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x000000FF) >>  0);
+        WIZCHIP.IF.SPI._write_byte(wb);
+    } else {								// burst operation
+        spi_data[0] = (AddrSel & 0x00FF0000) >> 16;
+        spi_data[1] = (AddrSel & 0x0000FF00) >> 8;
+        spi_data[2] = (AddrSel & 0x000000FF) >> 0;
+        spi_data[3] = wb;
+        WIZCHIP.IF.SPI._write_burst(spi_data, 4);
+    }
+
+    WIZCHIP.CS._deselect();
+    WIZCHIP_CRITICAL_EXIT();
+}
+
+void     WIZCHIP_READ_BUF(uint32_t AddrSel, uint8_t* pBuf, uint16_t len) {
+    uint8_t spi_data[3];
+    uint16_t i;
+
+    WIZCHIP_CRITICAL_ENTER();
+    WIZCHIP.CS._select();
+
+    AddrSel |= (_W5500_SPI_READ_ | _W5500_SPI_VDM_OP_);
+
+    if (!WIZCHIP.IF.SPI._read_burst || !WIZCHIP.IF.SPI._write_burst) {	// byte operation
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x00FF0000) >> 16);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x0000FF00) >>  8);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x000000FF) >>  0);
+        for (i = 0; i < len; i++) {
+            pBuf[i] = WIZCHIP.IF.SPI._read_byte();
+        }
+    } else {															// burst operation
+        spi_data[0] = (AddrSel & 0x00FF0000) >> 16;
+        spi_data[1] = (AddrSel & 0x0000FF00) >> 8;
+        spi_data[2] = (AddrSel & 0x000000FF) >> 0;
+        WIZCHIP.IF.SPI._write_burst(spi_data, 3);
+        WIZCHIP.IF.SPI._read_burst(pBuf, len);
+    }
+
+    WIZCHIP.CS._deselect();
+    WIZCHIP_CRITICAL_EXIT();
+}
+
+void     WIZCHIP_WRITE_BUF(uint32_t AddrSel, uint8_t* pBuf, uint16_t len) {
+    uint8_t spi_data[3];
+    uint16_t i;
+
+    WIZCHIP_CRITICAL_ENTER();
+    WIZCHIP.CS._select();
+
+    AddrSel |= (_W5500_SPI_WRITE_ | _W5500_SPI_VDM_OP_);
+
+    if (!WIZCHIP.IF.SPI._write_burst) {	// byte operation
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x00FF0000) >> 16);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x0000FF00) >>  8);
+        WIZCHIP.IF.SPI._write_byte((AddrSel & 0x000000FF) >>  0);
+        for (i = 0; i < len; i++) {
+            WIZCHIP.IF.SPI._write_byte(pBuf[i]);
+        }
+    } else {								// burst operation
+        spi_data[0] = (AddrSel & 0x00FF0000) >> 16;
+        spi_data[1] = (AddrSel & 0x0000FF00) >> 8;
+        spi_data[2] = (AddrSel & 0x000000FF) >> 0;
+        WIZCHIP.IF.SPI._write_burst(spi_data, 3);
+        WIZCHIP.IF.SPI._write_burst(pBuf, len);
+    }
+
+    WIZCHIP.CS._deselect();
+    WIZCHIP_CRITICAL_EXIT();
+}
+
+
+uint16_t getSn_TX_FSR(uint8_t sn) {
+    uint16_t val = 0, val1 = 0;
+
+    do {
+        val1 = WIZCHIP_READ(Sn_TX_FSR(sn));
+        val1 = (val1 << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_FSR(sn), 1));
+        if (val1 != 0) {
+            val = WIZCHIP_READ(Sn_TX_FSR(sn));
+            val = (val << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_FSR(sn), 1));
+        }
+    } while (val != val1);
+    return val;
+}
+
+
+uint16_t getSn_RX_RSR(uint8_t sn) {
+    uint16_t val = 0, val1 = 0;
+
+    do {
+        val1 = WIZCHIP_READ(Sn_RX_RSR(sn));
+        val1 = (val1 << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_RSR(sn), 1));
+        if (val1 != 0) {
+            val = WIZCHIP_READ(Sn_RX_RSR(sn));
+            val = (val << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_RSR(sn), 1));
+        }
+    } while (val != val1);
+    return val;
+}
+
+void wiz_send_data(uint8_t sn, uint8_t *wizdata, uint16_t len) {
+    uint16_t ptr = 0;
+    uint32_t addrsel = 0;
+
+    if (len == 0) {
+        return;
+    }
+    ptr = getSn_TX_WR(sn);
+    //M20140501 : implict type casting -> explict type casting
+    //addrsel = (ptr << 8) + (WIZCHIP_TXBUF_BLOCK(sn) << 3);
+    addrsel = ((uint32_t)ptr << 8) + (WIZCHIP_TXBUF_BLOCK(sn) << 3);
+    //
+    WIZCHIP_WRITE_BUF(addrsel, wizdata, len);
+
+    ptr += len;
+    setSn_TX_WR(sn, ptr);
+}
+
+void wiz_recv_data(uint8_t sn, uint8_t *wizdata, uint16_t len) {
+    uint16_t ptr = 0;
+    uint32_t addrsel = 0;
+
+    if (len == 0) {
+        return;
+    }
+    ptr = getSn_RX_RD(sn);
+    //M20140501 : implict type casting -> explict type casting
+    //addrsel = ((ptr << 8) + (WIZCHIP_RXBUF_BLOCK(sn) << 3);
+    addrsel = ((uint32_t)ptr << 8) + (WIZCHIP_RXBUF_BLOCK(sn) << 3);
+    //
+    WIZCHIP_READ_BUF(addrsel, wizdata, len);
+    ptr += len;
+
+    setSn_RX_RD(sn, ptr);
+}
+
+
+void wiz_recv_ignore(uint8_t sn, uint16_t len) {
+    uint16_t ptr = 0;
+
+    ptr = getSn_RX_RD(sn);
+    ptr += len;
+    setSn_RX_RD(sn, ptr);
+}
+
+#endif

--- a/third_party/ioLibrary_Driver/Ethernet/W5500/w5500.h
+++ b/third_party/ioLibrary_Driver/Ethernet/W5500/w5500.h
@@ -1,0 +1,2164 @@
+//*****************************************************************************
+//
+//! \file w5500.h
+//! \brief W5500 HAL Header File.
+//! \version 1.0.0
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+
+//
+
+#ifndef  _W5500_H_
+#define  _W5500_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "wizchip_conf.h"
+
+/// @cond DOXY_APPLY_CODE
+#if   (_WIZCHIP_ == 5500)
+/// @endcond
+
+#define _W5500_IO_BASE_              0x00000000
+
+#define _W5500_SPI_READ_			   (0x00 << 2) //< SPI interface Read operation in Control Phase
+#define _W5500_SPI_WRITE_			   (0x01 << 2) //< SPI interface Write operation in Control Phase
+
+#define WIZCHIP_CREG_BLOCK          0x00 	//< Common register block
+#define WIZCHIP_SREG_BLOCK(N)       (1+4*N) //< Socket N register block
+#define WIZCHIP_TXBUF_BLOCK(N)      (2+4*N) //< Socket N Tx buffer address block
+#define WIZCHIP_RXBUF_BLOCK(N)      (3+4*N) //< Socket N Rx buffer address block
+
+#define WIZCHIP_OFFSET_INC(ADDR, N)    (ADDR + (N<<8)) //< Increase offset address
+
+
+///////////////////////////////////////
+// Definition For Legacy Chip Driver //
+///////////////////////////////////////
+#define IINCHIP_READ(ADDR)                WIZCHIP_READ(ADDR)               ///< The defined for legacy chip driver
+#define IINCHIP_WRITE(ADDR,VAL)           WIZCHIP_WRITE(ADDR,VAL)          ///< The defined for legacy chip driver
+#define IINCHIP_READ_BUF(ADDR,BUF,LEN)    WIZCHIP_READ_BUF(ADDR,BUF,LEN)   ///< The defined for legacy chip driver
+#define IINCHIP_WRITE_BUF(ADDR,BUF,LEN)   WIZCHIP_WRITE(ADDR,BUF,LEN)      ///< The defined for legacy chip driver
+
+//////////////////////////////
+//--------------------------  defgroup ---------------------------------
+/**
+    @defgroup W5500 W5500
+
+    @brief WHIZCHIP register defines and I/O functions of @b W5500.
+
+    - @ref WIZCHIP_register : @ref Common_register_group and @ref Socket_register_group
+    - @ref WIZCHIP_IO_Functions : @ref Basic_IO_function, @ref Common_register_access_function and @ref Socket_register_access_function
+*/
+
+
+/**
+    @defgroup WIZCHIP_register WIZCHIP register
+    @ingroup W5500
+
+    @brief WHIZCHIP register defines register group of @b W5500.
+
+    - @ref Common_register_group : Common register group
+    - @ref Socket_register_group : \c SOCKET n register group
+*/
+
+
+/**
+    @defgroup WIZCHIP_IO_Functions WIZCHIP I/O functions
+    @ingroup W5500
+
+    @brief This supports the basic I/O functions for @ref WIZCHIP_register.
+
+    - <b> Basic I/O function </b> \n
+     WIZCHIP_READ(), WIZCHIP_WRITE(), WIZCHIP_READ_BUF(), WIZCHIP_WRITE_BUF() \n\n
+
+    - @ref Common_register_group <b>access functions</b> \n
+  	-# @b Mode \n
+      getMR(), setMR()
+  	-# @b Interrupt \n
+      getIR(), setIR(), getIMR(), setIMR(), getSIR(), setSIR(), getSIMR(), setSIMR(), getINTLEVEL(), setINTLEVEL()
+  	-# <b> Network Information </b> \n
+      getSHAR(), setSHAR(), getGAR(), setGAR(), getSUBR(), setSUBR(), getSIPR(), setSIPR()
+  	-# @b Retransmission \n
+      getRCR(), setRCR(), getRTR(), setRTR()
+  	-# @b PPPoE \n
+      getPTIMER(), setPTIMER(), getPMAGIC(), getPMAGIC(), getPSID(), setPSID(), getPHAR(), setPHAR(), getPMRU(), setPMRU()
+  	-# <b> ICMP packet </b>\n
+      getUIPR(), getUPORTR()
+  	-# @b etc. \n
+      getPHYCFGR(), setPHYCFGR(), getVERSIONR() \n\n
+
+    - \ref Socket_register_group <b>access functions</b> \n
+     -# <b> SOCKET control</b> \n
+        getSn_MR(), setSn_MR(), getSn_CR(), setSn_CR(), getSn_IMR(), setSn_IMR(), getSn_IR(), setSn_IR()
+     -# <b> SOCKET information</b> \n
+        getSn_SR(), getSn_DHAR(), setSn_DHAR(), getSn_PORT(), setSn_PORT(), getSn_DIPR(), setSn_DIPR(), getSn_DPORT(), setSn_DPORT()
+        getSn_MSSR(), setSn_MSSR()
+     -# <b> SOCKET communication </b> \n
+        getSn_RXBUF_SIZE(), setSn_RXBUF_SIZE(), getSn_TXBUF_SIZE(), setSn_TXBUF_SIZE() \n
+        getSn_TX_RD(), getSn_TX_WR(), setSn_TX_WR() \n
+        getSn_RX_RD(), setSn_RX_RD(), getSn_RX_WR() \n
+        getSn_TX_FSR(), getSn_RX_RSR(), getSn_KPALVTR(), setSn_KPALVTR()
+     -# <b> IP header field </b> \n
+        getSn_FRAG(), setSn_FRAG(),  getSn_TOS(), setSn_TOS() \n
+        getSn_TTL(), setSn_TTL()
+*/
+
+
+
+/**
+    @defgroup Common_register_group Common register
+    @ingroup WIZCHIP_register
+
+    @brief Common register group\n
+    It set the basic for the networking\n
+    It set the configuration such as interrupt, network information, ICMP, etc.
+    @details
+    @sa MR : Mode register.
+    @sa GAR, SUBR, SHAR, SIPR
+    @sa INTLEVEL, IR, IMR, SIR, SIMR : Interrupt.
+    @sa _RTR_, _RCR_ : Data retransmission.
+    @sa PTIMER, PMAGIC, PHAR, PSID, PMRU : PPPoE.
+    @sa UIPR, UPORTR : ICMP message.
+    @sa PHYCFGR, VERSIONR : etc.
+*/
+
+
+
+/**
+    @defgroup Socket_register_group Socket register
+    @ingroup WIZCHIP_register
+
+    @brief Socket register group.\n
+    Socket register configures and control SOCKETn which is necessary to data communication.
+    @details
+    @sa Sn_MR, Sn_CR, Sn_IR, Sn_IMR : SOCKETn Control
+    @sa Sn_SR, Sn_PORT, Sn_DHAR, Sn_DIPR, Sn_DPORT : SOCKETn Information
+    @sa Sn_MSSR, Sn_TOS, Sn_TTL, Sn_KPALVTR, Sn_FRAG : Internet protocol.
+    @sa Sn_RXBUF_SIZE, Sn_TXBUF_SIZE, Sn_TX_FSR, Sn_TX_RD, Sn_TX_WR, Sn_RX_RSR, Sn_RX_RD, Sn_RX_WR : Data communication
+*/
+
+
+
+/**
+    @defgroup Basic_IO_function Basic I/O function
+    @ingroup WIZCHIP_IO_Functions
+    @brief These are basic input/output functions to read values from register or write values to register.
+*/
+
+/**
+    @defgroup Common_register_access_function Common register access functions
+    @ingroup WIZCHIP_IO_Functions
+    @brief These are functions to access <b>common registers</b>.
+*/
+
+/**
+    @defgroup Socket_register_access_function Socket register access functions
+    @ingroup WIZCHIP_IO_Functions
+    @brief These are functions to access <b>socket registers</b>.
+*/
+
+//------------------------------- defgroup end --------------------------------------------
+//----------------------------- W5500 Common Registers IOMAP -----------------------------
+/**
+    @ingroup Common_register_group
+    @brief Mode Register address(R/W)\n
+    @ref MR is used for S/W reset, ping block mode, PPPoE mode and etc.
+    @details Each bit of @ref MR defined as follows.
+    <table>
+  		<tr>  <td>7</td> <td>6</td> <td>5</td> <td>4</td> <td>3</td> <td>2</td> <td>1</td> <td>0</td>   </tr>
+  		<tr>  <td>RST</td> <td>Reserved</td> <td>WOL</td> <td>PB</td> <td>PPPoE</td> <td>Reserved</td> <td>FARP</td> <td>Reserved</td> </tr>
+    </table>
+    - \ref MR_RST		 	: Reset
+    - \ref MR_WOL       	: Wake on LAN
+    - \ref MR_PB         : Ping block
+    - \ref MR_PPPOE      : PPPoE mode
+    - \ref MR_FARP			: Force ARP mode
+*/
+#define MR                 (_W5500_IO_BASE_ + (0x0000 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Gateway IP Register address(R/W)
+    @details @ref GAR configures the default gateway address.
+*/
+#define GAR                (_W5500_IO_BASE_ + (0x0001 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Subnet mask Register address(R/W)
+    @details @ref SUBR configures the subnet mask address.
+*/
+#define SUBR               (_W5500_IO_BASE_ + (0x0005 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Source MAC Register address(R/W)
+    @details @ref SHAR configures the source hardware address.
+*/
+#define SHAR               (_W5500_IO_BASE_ + (0x0009 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Source IP Register address(R/W)
+    @details @ref SIPR configures the source IP address.
+*/
+#define SIPR               (_W5500_IO_BASE_ + (0x000F << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Set Interrupt low level timer register address(R/W)
+    @details @ref INTLEVEL configures the Interrupt Assert Time.
+*/
+#define INTLEVEL           (_W5500_IO_BASE_ + (0x0013 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Interrupt Register(R/W)
+    @details @ref IR indicates the interrupt status. Each bit of @ref IR will be still until the bit will be written to by the host.
+    If @ref IR is not equal to x00 INTn PIN is asserted to low until it is x00\n\n
+    Each bit of @ref IR defined as follows.
+    <table>
+  		<tr>  <td>7</td> <td>6</td> <td>5</td> <td>4</td> <td>3</td> <td>2</td> <td>1</td> <td>0</td>   </tr>
+  		<tr>  <td>CONFLICT</td> <td>UNREACH</td> <td>PPPoE</td> <td>MP</td> <td>Reserved</td> <td>Reserved</td> <td>Reserved</td> <td>Reserved</td> </tr>
+    </table>
+    - \ref IR_CONFLICT : IP conflict
+    - \ref IR_UNREACH  : Destination unreachable
+    - \ref IR_PPPoE	  : PPPoE connection close
+    - \ref IR_MP		  : Magic packet
+*/
+#define IR                 (_W5500_IO_BASE_ + (0x0015 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Interrupt mask register(R/W)
+    @details @ref _IMR_ is used to mask interrupts. Each bit of @ref _IMR_ corresponds to each bit of @ref IR.
+    When a bit of @ref _IMR_ is and the corresponding bit of @ref IR is  an interrupt will be issued. In other words,
+    if a bit of @ref _IMR_ is  an interrupt will not be issued even if the corresponding bit of @ref IR is \n\n
+    Each bit of @ref _IMR_ defined as the following.
+    <table>
+  		<tr>  <td>7</td> <td>6</td> <td>5</td> <td>4</td> <td>3</td> <td>2</td> <td>1</td> <td>0</td>   </tr>
+  		<tr>  <td>IM_IR7</td> <td>IM_IR6</td> <td>IM_IR5</td> <td>IM_IR4</td> <td>Reserved</td> <td>Reserved</td> <td>Reserved</td> <td>Reserved</td> </tr>
+    </table>
+    - \ref IM_IR7 : IP Conflict Interrupt Mask
+    - \ref IM_IR6 : Destination unreachable Interrupt Mask
+    - \ref IM_IR5 : PPPoE Close Interrupt Mask
+    - \ref IM_IR4 : Magic Packet Interrupt Mask
+*/
+//M20150401 : Rename SYMBOE ( Re-define error in a compile)
+//#define IMR                (_W5500_IO_BASE_ + (0x0016 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+#define _IMR_                (_W5500_IO_BASE_ + (0x0016 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Socket Interrupt Register(R/W)
+    @details @ref SIR indicates the interrupt status of Socket.\n
+    Each bit of @ref SIR be still until @ref Sn_IR is cleared by the host.\n
+    If @ref Sn_IR is not equal to x00 the n-th bit of @ref SIR is and INTn PIN is asserted until @ref SIR is x00 */
+#define SIR                (_W5500_IO_BASE_ + (0x0017 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Socket Interrupt Mask Register(R/W)
+    @details Each bit of @ref SIMR corresponds to each bit of @ref SIR.
+    When a bit of @ref SIMR is and the corresponding bit of @ref SIR is  Interrupt will be issued.
+    In other words, if a bit of @ref SIMR is  an interrupt will be not issued even if the corresponding bit of @ref SIR is
+*/
+#define SIMR               (_W5500_IO_BASE_ + (0x0018 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Timeout register address( 1 is 100us )(R/W)
+    @details @ref _RTR_ configures the retransmission timeout period. The unit of timeout period is 100us and the default of @ref _RTR_ is x07D0.
+    And so the default timeout period is 200ms(100us X 2000). During the time configured by @ref _RTR_, W5500 waits for the peer response
+    to the packet that is transmitted by \ref Sn_CR (CONNECT, DISCON, CLOSE, SEND, SEND_MAC, SEND_KEEP command).
+    If the peer does not respond within the @ref _RTR_ time, W5500 retransmits the packet or issues timeout.
+*/
+//M20150401 : Rename SYMBOE ( Re-define error in a compile)
+//#define RTR                (_W5500_IO_BASE_ + (0x0019 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+#define _RTR_                (_W5500_IO_BASE_ + (0x0019 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Retry count register(R/W)
+    @details @ref _RCR_ configures the number of time of retransmission.
+    When retransmission occurs as many as ref _RCR_+1 Timeout interrupt is issued (@ref Sn_IR_TIMEOUT = '1').
+*/
+//M20150401 : Rename SYMBOE ( Re-define error in a compile)
+//#define RCR                (_W5500_IO_BASE_ + (0x001B << 8) + (WIZCHIP_CREG_BLOCK << 3))
+#define _RCR_                (_W5500_IO_BASE_ + (0x001B << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PPP LCP Request Timer register  in PPPoE mode(R/W)
+    @details @ref PTIMER configures the time for sending LCP echo request. The unit of time is 25ms.
+*/
+#define PTIMER             (_W5500_IO_BASE_ + (0x001C << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PPP LCP Magic number register  in PPPoE mode(R/W)
+    @details @ref PMAGIC configures the 4bytes magic number to be used in LCP negotiation.
+*/
+#define PMAGIC             (_W5500_IO_BASE_ + (0x001D << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PPP Destination MAC Register address(R/W)
+    @details @ref PHAR configures the PPPoE server hardware address that is acquired during PPPoE connection process.
+*/
+#define PHAR                (_W5500_IO_BASE_ + (0x001E << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PPP Session Identification Register(R/W)
+    @details @ref PSID configures the PPPoE sever session ID acquired during PPPoE connection process.
+*/
+#define PSID               (_W5500_IO_BASE_ + (0x0024 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PPP Maximum Segment Size(MSS) register(R/W)
+    @details @ref PMRU configures the maximum receive unit of PPPoE.
+*/
+#define PMRU               (_W5500_IO_BASE_ + (0x0026 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Unreachable IP register address in UDP mode(R)
+    @details W5500 receives an ICMP packet(Destination port unreachable) when data is sent to a port number
+    which socket is not open and @ref IR_UNREACH bit of @ref IR becomes and @ref UIPR & @ref UPORTR indicates
+    the destination IP address & port number respectively.
+*/
+#define UIPR               (_W5500_IO_BASE_ + (0x0028 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief Unreachable Port register address in UDP mode(R)
+    @details W5500 receives an ICMP packet(Destination port unreachable) when data is sent to a port number
+    which socket is not open and @ref IR_UNREACH bit of @ref IR becomes and @ref UIPR & @ref UPORTR
+    indicates the destination IP address & port number respectively.
+*/
+#define UPORTR              (_W5500_IO_BASE_ + (0x002C << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief PHY Status Register(R/W)
+    @details @ref PHYCFGR configures PHY operation mode and resets PHY. In addition, @ref PHYCFGR indicates the status of PHY such as duplex, Speed, Link.
+*/
+#define PHYCFGR            (_W5500_IO_BASE_ + (0x002E << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+// Reserved			         (_W5500_IO_BASE_ + (0x002F << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0030 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0031 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0032 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0033 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0034 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0035 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0036 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0037 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0038 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+/**
+    @ingroup Common_register_group
+    @brief chip version register address(R)
+    @details @ref VERSIONR always indicates the W5500 version as @b 0x04.
+*/
+#define VERSIONR           (_W5500_IO_BASE_ + (0x0039 << 8) + (WIZCHIP_CREG_BLOCK << 3))
+
+
+//----------------------------- W5500 Socket Registers IOMAP -----------------------------
+/**
+    @ingroup Socket_register_group
+    @brief socket Mode register(R/W)
+    @details @ref Sn_MR configures the option or protocol type of Socket n.\n\n
+    Each bit of @ref Sn_MR defined as the following.
+    <table>
+  		<tr>  <td>7</td> <td>6</td> <td>5</td> <td>4</td> <td>3</td> <td>2</td> <td>1</td> <td>0</td>   </tr>
+  		<tr>  <td>MULTI/MFEN</td> <td>BCASTB</td> <td>ND/MC/MMB</td> <td>UCASTB/MIP6B</td> <td>Protocol[3]</td> <td>Protocol[2]</td> <td>Protocol[1]</td> <td>Protocol[0]</td> </tr>
+    </table>
+    - @ref Sn_MR_MULTI	: Support UDP Multicasting
+    - @ref Sn_MR_BCASTB	: Broadcast block <b>in UDP Multicasting</b>
+    - @ref Sn_MR_ND		: No Delayed Ack(TCP) flag
+    - @ref Sn_MR_MC   	: IGMP version used <b>in UDP mulitcasting</b>
+    - @ref Sn_MR_MMB    	: Multicast Blocking <b>in @ref Sn_MR_MACRAW mode</b>
+    - @ref Sn_MR_UCASTB	: Unicast Block <b>in UDP Multicating</b>
+    - @ref Sn_MR_MIP6B   : IPv6 packet Blocking <b>in @ref Sn_MR_MACRAW mode</b>
+    - <b>Protocol</b>
+    <table>
+  		<tr>   <td><b>Protocol[3]</b></td> <td><b>Protocol[2]</b></td> <td><b>Protocol[1]</b></td> <td><b>Protocol[0]</b></td> <td>@b Meaning</td>   </tr>
+  		<tr>   <td>0</td> <td>0</td> <td>0</td> <td>0</td> <td>Closed</td>   </tr>
+  		<tr>   <td>0</td> <td>0</td> <td>0</td> <td>1</td> <td>TCP</td>   </tr>
+  		<tr>   <td>0</td> <td>0</td> <td>1</td> <td>0</td> <td>UDP</td>   </tr>
+  		<tr>   <td>0</td> <td>1</td> <td>0</td> <td>0</td> <td>MACRAW</td>   </tr>
+    </table>
+ 	- @ref Sn_MR_MACRAW	: MAC LAYER RAW SOCK \n
+    - @ref Sn_MR_UDP		: UDP
+    - @ref Sn_MR_TCP		: TCP
+    - @ref Sn_MR_CLOSE	: Unused socket
+    @note MACRAW mode should be only used in Socket 0.
+*/
+#define Sn_MR(N)           (_W5500_IO_BASE_ + (0x0000 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Socket command register(R/W)
+    @details This is used to set the command for Socket n such as OPEN, CLOSE, CONNECT, LISTEN, SEND, and RECEIVE.\n
+    After W5500 accepts the command, the @ref Sn_CR register is automatically cleared to 0x00.
+    Even though @ref Sn_CR is cleared to 0x00, the command is still being processed.\n
+    To check whether the command is completed or not, please check the @ref Sn_IR or @ref Sn_SR.
+    - @ref Sn_CR_OPEN 		: Initialize or open socket.
+    - @ref Sn_CR_LISTEN 		: Wait connection request in TCP mode(<b>Server mode</b>)
+    - @ref Sn_CR_CONNECT 	: Send connection request in TCP mode(<b>Client mode</b>)
+    - @ref Sn_CR_DISCON 		: Send closing request in TCP mode.
+    - @ref Sn_CR_CLOSE   	: Close socket.
+    - @ref Sn_CR_SEND    	: Update TX buffer pointer and send data.
+    - @ref Sn_CR_SEND_MAC	: Send data with MAC address, so without ARP process.
+    - @ref Sn_CR_SEND_KEEP 	: Send keep alive message.
+    - @ref Sn_CR_RECV		: Update RX buffer pointer and receive data.
+*/
+#define Sn_CR(N)           (_W5500_IO_BASE_ + (0x0001 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Socket interrupt register(R)
+    @details @ref Sn_IR indicates the status of Socket Interrupt such as establishment, termination, receiving data, timeout).\n
+    When an interrupt occurs and the corresponding bit of @ref Sn_IMR is  the corresponding bit of @ref Sn_IR becomes \n
+    In order to clear the @ref Sn_IR bit, the host should write the bit to \n
+    <table>
+  		<tr>  <td>7</td> <td>6</td> <td>5</td> <td>4</td> <td>3</td> <td>2</td> <td>1</td> <td>0</td>   </tr>
+  		<tr>  <td>Reserved</td> <td>Reserved</td> <td>Reserved</td> <td>SEND_OK</td> <td>TIMEOUT</td> <td>RECV</td> <td>DISCON</td> <td>CON</td> </tr>
+    </table>
+    - \ref Sn_IR_SENDOK : <b>SEND_OK Interrupt</b>
+    - \ref Sn_IR_TIMEOUT : <b>TIMEOUT Interrupt</b>
+    - \ref Sn_IR_RECV : <b>RECV Interrupt</b>
+    - \ref Sn_IR_DISCON : <b>DISCON Interrupt</b>
+    - \ref Sn_IR_CON : <b>CON Interrupt</b>
+*/
+#define Sn_IR(N)           (_W5500_IO_BASE_ + (0x0002 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Socket status register(R)
+    @details @ref Sn_SR indicates the status of Socket n.\n
+    The status of Socket n is changed by @ref Sn_CR or some special control packet as SYN, FIN packet in TCP.
+    @par Normal status
+    - @ref SOCK_CLOSED 		: Closed
+    - @ref SOCK_INIT   		: Initiate state
+    - @ref SOCK_LISTEN    	: Listen state
+    - @ref SOCK_ESTABLISHED 	: Success to connect
+    - @ref SOCK_CLOSE_WAIT   : Closing state
+    - @ref SOCK_UDP   		: UDP socket
+    - @ref SOCK_MACRAW  		: MAC raw mode socket
+    @par Temporary status during changing the status of Socket n.
+    - @ref SOCK_SYNSENT   	: This indicates Socket n sent the connect-request packet (SYN packet) to a peer.
+    - @ref SOCK_SYNRECV    	: It indicates Socket n successfully received the connect-request packet (SYN packet) from a peer.
+    - @ref SOCK_FIN_WAIT		: Connection state
+    - @ref SOCK_CLOSING		: Closing state
+    - @ref SOCK_TIME_WAIT	: Closing state
+    - @ref SOCK_LAST_ACK 	: Closing state
+*/
+#define Sn_SR(N)           (_W5500_IO_BASE_ + (0x0003 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief source port register(R/W)
+    @details @ref Sn_PORT configures the source port number of Socket n.
+    It is valid when Socket n is used in TCP/UDP mode. It should be set before OPEN command is ordered.
+*/
+#define Sn_PORT(N)         (_W5500_IO_BASE_ + (0x0004 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Peer MAC register address(R/W)
+    @details @ref Sn_DHAR configures the destination hardware address of Socket n when using SEND_MAC command in UDP mode or
+    it indicates that it is acquired in ARP-process by CONNECT/SEND command.
+*/
+#define Sn_DHAR(N)         (_W5500_IO_BASE_ + (0x0006 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Peer IP register address(R/W)
+    @details @ref Sn_DIPR configures or indicates the destination IP address of Socket n. It is valid when Socket n is used in TCP/UDP mode.
+    In TCP client mode, it configures an IP address of TCP serverbefore CONNECT command.
+    In TCP server mode, it indicates an IP address of TCP clientafter successfully establishing connection.
+    In UDP mode, it configures an IP address of peer to be received the UDP packet by SEND or SEND_MAC command.
+*/
+#define Sn_DIPR(N)         (_W5500_IO_BASE_ + (0x000C << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Peer port register address(R/W)
+    @details @ref Sn_DPORT configures or indicates the destination port number of Socket n. It is valid when Socket n is used in TCP/UDP mode.
+    In TCP clientmode, it configures the listen port number of TCP serverbefore CONNECT command.
+    In TCP Servermode, it indicates the port number of TCP client after successfully establishing connection.
+    In UDP mode, it configures the port number of peer to be transmitted the UDP packet by SEND/SEND_MAC command.
+*/
+#define Sn_DPORT(N)        (_W5500_IO_BASE_ + (0x0010 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Maximum Segment Size(Sn_MSSR0) register address(R/W)
+    @details @ref Sn_MSSR configures or indicates the MTU(Maximum Transfer Unit) of Socket n.
+*/
+#define Sn_MSSR(N)         (_W5500_IO_BASE_ + (0x0012 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+// Reserved			         (_W5500_IO_BASE_ + (0x0014 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief IP Type of Service(TOS) Register(R/W)
+    @details @ref Sn_TOS configures the TOS(Type Of Service field in IP Header) of Socket n.
+    It is set before OPEN command.
+*/
+#define Sn_TOS(N)          (_W5500_IO_BASE_ + (0x0015 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+/**
+    @ingroup Socket_register_group
+    @brief IP Time to live(TTL) Register(R/W)
+    @details @ref Sn_TTL configures the TTL(Time To Live field in IP header) of Socket n.
+    It is set before OPEN command.
+*/
+#define Sn_TTL(N)          (_W5500_IO_BASE_ + (0x0016 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0017 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0018 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x0019 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x001A << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x001B << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x001C << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+// Reserved			         (_W5500_IO_BASE_ + (0x001D << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Receive memory size register(R/W)
+    @details @ref Sn_RXBUF_SIZE configures the RX buffer block size of Socket n.
+    Socket n RX Buffer Block size can be configured with 1,2,4,8, and 16 Kbytes.
+    If a different size is configured, the data cannot be normally received from a peer.
+    Although Socket n RX Buffer Block size is initially configured to 2Kbytes,
+    user can re-configure its size using @ref Sn_RXBUF_SIZE. The total sum of @ref Sn_RXBUF_SIZE can not be exceed 16Kbytes.
+    When exceeded, the data reception error is occurred.
+*/
+#define Sn_RXBUF_SIZE(N)   (_W5500_IO_BASE_ + (0x001E << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Transmit memory size register(R/W)
+    @details @ref Sn_TXBUF_SIZE configures the TX buffer block size of Socket n. Socket n TX Buffer Block size can be configured with 1,2,4,8, and 16 Kbytes.
+    If a different size is configured, the data can�t be normally transmitted to a peer.
+    Although Socket n TX Buffer Block size is initially configured to 2Kbytes,
+    user can be re-configure its size using @ref Sn_TXBUF_SIZE. The total sum of @ref Sn_TXBUF_SIZE can not be exceed 16Kbytes.
+    When exceeded, the data transmission error is occurred.
+*/
+#define Sn_TXBUF_SIZE(N)   (_W5500_IO_BASE_ + (0x001F << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Transmit free memory size register(R)
+    @details @ref Sn_TX_FSR indicates the free size of Socket n TX Buffer Block. It is initialized to the configured size by @ref Sn_TXBUF_SIZE.
+    Data bigger than @ref Sn_TX_FSR should not be saved in the Socket n TX Buffer because the bigger data overwrites the previous saved data not yet sent.
+    Therefore, check before saving the data to the Socket n TX Buffer, and if data is equal or smaller than its checked size,
+    transmit the data with SEND/SEND_MAC command after saving the data in Socket n TX buffer. But, if data is bigger than its checked size,
+    transmit the data after dividing into the checked size and saving in the Socket n TX buffer.
+*/
+#define Sn_TX_FSR(N)       (_W5500_IO_BASE_ + (0x0020 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Transmit memory read pointer register address(R)
+    @details @ref Sn_TX_RD is initialized by OPEN command. However, if Sn_MR(P[3:0]) is TCP mode(001, it is re-initialized while connecting with TCP.
+    After its initialization, it is auto-increased by SEND command.
+    SEND command transmits the saved data from the current @ref Sn_TX_RD to the @ref Sn_TX_WR in the Socket n TX Buffer.
+    After transmitting the saved data, the SEND command increases the @ref Sn_TX_RD as same as the @ref Sn_TX_WR.
+    If its increment value exceeds the maximum value 0xFFFF, (greater than 0x10000 and the carry bit occurs),
+    then the carry bit is ignored and will automatically update with the lower 16bits value.
+*/
+#define Sn_TX_RD(N)        (_W5500_IO_BASE_ + (0x0022 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Transmit memory write pointer register address(R/W)
+    @details @ref Sn_TX_WR is initialized by OPEN command. However, if Sn_MR(P[3:0]) is TCP mode(001, it is re-initialized while connecting with TCP.\n
+    It should be read or be updated like as follows.\n
+    1. Read the starting address for saving the transmitting data.\n
+    2. Save the transmitting data from the starting address of Socket n TX buffer.\n
+    3. After saving the transmitting data, update @ref Sn_TX_WR to the increased value as many as transmitting data size.
+    If the increment value exceeds the maximum value 0xFFFF(greater than 0x10000 and the carry bit occurs),
+    then the carry bit is ignored and will automatically update with the lower 16bits value.\n
+    4. Transmit the saved data in Socket n TX Buffer by using SEND/SEND command
+*/
+#define Sn_TX_WR(N)        (_W5500_IO_BASE_ + (0x0024 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Received data size register(R)
+    @details @ref Sn_RX_RSR indicates the data size received and saved in Socket n RX Buffer.
+    @ref Sn_RX_RSR does not exceed the @ref Sn_RXBUF_SIZE and is calculated as the difference between
+    �Socket n RX Write Pointer (@ref Sn_RX_WR)and �Socket n RX Read Pointer (@ref Sn_RX_RD)
+*/
+#define Sn_RX_RSR(N)       (_W5500_IO_BASE_ + (0x0026 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Read point of Receive memory(R/W)
+    @details @ref Sn_RX_RD is initialized by OPEN command. Make sure to be read or updated as follows.\n
+    1. Read the starting save address of the received data.\n
+    2. Read data from the starting address of Socket n RX Buffer.\n
+    3. After reading the received data, Update @ref Sn_RX_RD to the increased value as many as the reading size.
+    If the increment value exceeds the maximum value 0xFFFF, that is, is greater than 0x10000 and the carry bit occurs,
+    update with the lower 16bits value ignored the carry bit.\n
+    4. Order RECV command is for notifying the updated @ref Sn_RX_RD to W5500.
+*/
+#define Sn_RX_RD(N)        (_W5500_IO_BASE_ + (0x0028 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Write point of Receive memory(R)
+    @details @ref Sn_RX_WR is initialized by OPEN command and it is auto-increased by the data reception.
+    If the increased value exceeds the maximum value 0xFFFF, (greater than 0x10000 and the carry bit occurs),
+    then the carry bit is ignored and will automatically update with the lower 16bits value.
+*/
+#define Sn_RX_WR(N)        (_W5500_IO_BASE_ + (0x002A << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief socket interrupt mask register(R)
+    @details @ref Sn_IMR masks the interrupt of Socket n.
+    Each bit corresponds to each bit of @ref Sn_IR. When a Socket n Interrupt is occurred and the corresponding bit of @ref Sn_IMR is
+    the corresponding bit of @ref Sn_IR becomes  When both the corresponding bit of @ref Sn_IMR and @ref Sn_IR are and the n-th bit of @ref IR is
+    Host is interrupted by asserted INTn PIN to low.
+*/
+#define Sn_IMR(N)          (_W5500_IO_BASE_ + (0x002C << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Fragment field value in IP header register(R/W)
+    @details @ref Sn_FRAG configures the FRAG(Fragment field in IP header).
+*/
+#define Sn_FRAG(N)         (_W5500_IO_BASE_ + (0x002D << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+/**
+    @ingroup Socket_register_group
+    @brief Keep Alive Timer register(R/W)
+    @details @ref Sn_KPALVTR configures the transmitting timer of �KEEP ALIVE(KA)packet of SOCKETn. It is valid only in TCP mode,
+    and ignored in other modes. The time unit is 5s.
+    KA packet is transmittable after @ref Sn_SR is changed to SOCK_ESTABLISHED and after the data is transmitted or received to/from a peer at least once.
+    In case of '@ref Sn_KPALVTR > 0', W5500 automatically transmits KA packet after time-period for checking the TCP connection (Auto-keepalive-process).
+    In case of '@ref Sn_KPALVTR = 0', Auto-keep-alive-process will not operate,
+    and KA packet can be transmitted by SEND_KEEP command by the host (Manual-keep-alive-process).
+    Manual-keep-alive-process is ignored in case of '@ref Sn_KPALVTR > 0'.
+*/
+#define Sn_KPALVTR(N)      (_W5500_IO_BASE_ + (0x002F << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+//#define Sn_TSR(N)          (_W5500_IO_BASE_ + (0x0030 << 8) + (WIZCHIP_SREG_BLOCK(N) << 3))
+
+
+//----------------------------- W5500 Register values  -----------------------------
+
+/* MODE register values */
+/**
+    @brief Reset
+    @details If this bit is  All internal registers will be initialized. It will be automatically cleared as after S/W reset.
+*/
+#define MR_RST                       0x80
+
+/**
+    @brief Wake on LAN
+    @details 0 : Disable WOL mode\n
+    1 : Enable WOL mode\n
+    If WOL mode is enabled and the received magic packet over UDP has been normally processed, the Interrupt PIN (INTn) asserts to low.
+    When using WOL mode, the UDP Socket should be opened with any source port number. (Refer to Socket n Mode Register (@ref Sn_MR) for opening Socket.)
+    @note The magic packet over UDP supported by W5500 consists of 6 bytes synchronization stream (xFFFFFFFFFFFF and
+    16 times Target MAC address stream in UDP payload. The options such like password are ignored. You can use any UDP source port number for WOL mode.
+*/
+#define MR_WOL                       0x20
+
+/**
+    @brief Ping block
+    @details 0 : Disable Ping block\n
+    1 : Enable Ping block\n
+    If the bit is  it blocks the response to a ping request.
+*/
+#define MR_PB                        0x10
+
+/**
+    @brief Enable PPPoE
+    @details 0 : DisablePPPoE mode\n
+    1 : EnablePPPoE mode\n
+    If you use ADSL, this bit should be
+*/
+#define MR_PPPOE                     0x08
+
+/**
+    @brief Enable UDP_FORCE_ARP CHECHK
+    @details 0 : Disable Force ARP mode\n
+    1 : Enable Force ARP mode\n
+    In Force ARP mode, It forces on sending ARP Request whenever data is sent.
+*/
+#define MR_FARP                      0x02
+
+/* IR register values */
+/**
+    @brief Check IP conflict.
+    @details Bit is set as when own source IP address is same with the sender IP address in the received ARP request.
+*/
+#define IR_CONFLICT                  0x80
+
+/**
+    @brief Get the destination unreachable message in UDP sending.
+    @details When receiving the ICMP (Destination port unreachable) packet, this bit is set as
+    When this bit is  Destination Information such as IP address and Port number may be checked with the corresponding @ref UIPR & @ref UPORTR.
+*/
+#define IR_UNREACH                   0x40
+
+/**
+    @brief Get the PPPoE close message.
+    @details When PPPoE is disconnected during PPPoE mode, this bit is set.
+*/
+#define IR_PPPoE                     0x20
+
+/**
+    @brief Get the magic packet interrupt.
+    @details When WOL mode is enabled and receives the magic packet over UDP, this bit is set.
+*/
+#define IR_MP                        0x10
+
+
+/* PHYCFGR register value */
+#define PHYCFGR_RST                  ~(1<<7)  //< For PHY reset, must operate AND mask.
+#define PHYCFGR_OPMD                 (1<<6)   // Configre PHY with OPMDC value
+#define PHYCFGR_OPMDC_ALLA           (7<<3)
+#define PHYCFGR_OPMDC_PDOWN          (6<<3)
+#define PHYCFGR_OPMDC_NA             (5<<3)
+#define PHYCFGR_OPMDC_100FA          (4<<3)
+#define PHYCFGR_OPMDC_100F           (3<<3)
+#define PHYCFGR_OPMDC_100H           (2<<3)
+#define PHYCFGR_OPMDC_10F            (1<<3)
+#define PHYCFGR_OPMDC_10H            (0<<3)
+#define PHYCFGR_DPX_FULL             (1<<2)
+#define PHYCFGR_DPX_HALF             (0<<2)
+#define PHYCFGR_SPD_100              (1<<1)
+#define PHYCFGR_SPD_10               (0<<1)
+#define PHYCFGR_LNK_ON               (1<<0)
+#define PHYCFGR_LNK_OFF              (0<<0)
+
+/* IMR register values */
+/**
+    @brief IP Conflict Interrupt Mask.
+    @details 0: Disable IP Conflict Interrupt\n
+    1: Enable IP Conflict Interrupt
+*/
+#define IM_IR7                  	 0x80
+
+/**
+    @brief Destination unreachable Interrupt Mask.
+    @details 0: Disable Destination unreachable Interrupt\n
+    1: Enable Destination unreachable Interrupt
+*/
+#define IM_IR6                  	 0x40
+
+/**
+    @brief PPPoE Close Interrupt Mask.
+    @details 0: Disable PPPoE Close Interrupt\n
+    1: Enable PPPoE Close Interrupt
+*/
+#define IM_IR5                  	 0x20
+
+/**
+    @brief Magic Packet Interrupt Mask.
+    @details 0: Disable Magic Packet Interrupt\n
+    1: Enable Magic Packet Interrupt
+*/
+#define IM_IR4                  	 0x10
+
+/* Sn_MR Default values */
+/**
+    @brief Support UDP Multicasting
+    @details 0 : disable Multicasting\n
+    1 : enable Multicasting\n
+    This bit is applied only during UDP mode(P[3:0] = 010.\n
+    To use multicasting, @ref Sn_DIPR & @ref Sn_DPORT should be respectively configured with the multicast group IP address & port number
+    before Socket n is opened by OPEN command of @ref Sn_CR.
+*/
+#define Sn_MR_MULTI                  0x80
+
+/**
+    @brief Broadcast block in UDP Multicasting.
+    @details 0 : disable Broadcast Blocking\n
+    1 : enable Broadcast Blocking\n
+    This bit blocks to receive broadcasting packet during UDP mode(P[3:0] = 010.\m
+    In addition, This bit does when MACRAW mode(P[3:0] = 100
+*/
+#define Sn_MR_BCASTB                 0x40
+
+/**
+    @brief No Delayed Ack(TCP), Multicast flag
+    @details 0 : Disable No Delayed ACK option\n
+    1 : Enable No Delayed ACK option\n
+    This bit is applied only during TCP mode (P[3:0] = 001.\n
+    When this bit is  It sends the ACK packet without delay as soon as a Data packet is received from a peer.\n
+    When this bit is  It sends the ACK packet after waiting for the timeout time configured by @ref _RTR_.
+*/
+#define Sn_MR_ND                     0x20
+
+/**
+    @brief Unicast Block in UDP Multicasting
+    @details 0 : disable Unicast Blocking\n
+    1 : enable Unicast Blocking\n
+    This bit blocks receiving the unicast packet during UDP mode(P[3:0] = 010 and MULTI =
+*/
+#define Sn_MR_UCASTB                 0x10
+
+/**
+    @brief MAC LAYER RAW SOCK
+    @details This configures the protocol mode of Socket n.
+    @note MACRAW mode should be only used in Socket 0.
+*/
+#define Sn_MR_MACRAW                 0x04
+
+#define Sn_MR_IPRAW                  0x03     /**< IP LAYER RAW SOCK */
+
+/**
+    @brief UDP
+    @details This configures the protocol mode of Socket n.
+*/
+#define Sn_MR_UDP                    0x02
+
+/**
+    @brief TCP
+    @details This configures the protocol mode of Socket n.
+*/
+#define Sn_MR_TCP                    0x01
+
+/**
+    @brief Unused socket
+    @details This configures the protocol mode of Socket n.
+*/
+#define Sn_MR_CLOSE                  0x00
+
+/* Sn_MR values used with Sn_MR_MACRAW */
+/**
+    @brief MAC filter enable in @ref Sn_MR_MACRAW mode
+    @details 0 : disable MAC Filtering\n
+    1 : enable MAC Filtering\n
+    This bit is applied only during MACRAW mode(P[3:0] = 100.\n
+    When set as  W5500 can only receive broadcasting packet or packet sent to itself.
+    When this bit is  W5500 can receive all packets on Ethernet.
+    If user wants to implement Hybrid TCP/IP stack,
+    it is recommended that this bit is set as for reducing host overhead to process the all received packets.
+*/
+#define Sn_MR_MFEN                   Sn_MR_MULTI
+
+/**
+    @brief Multicast Blocking in @ref Sn_MR_MACRAW mode
+    @details 0 : using IGMP version 2\n
+    1 : using IGMP version 1\n
+    This bit is applied only during UDP mode(P[3:0] = 010 and MULTI =
+    It configures the version for IGMP messages (Join/Leave/Report).
+*/
+#define Sn_MR_MMB                    Sn_MR_ND
+
+/**
+    @brief IPv6 packet Blocking in @ref Sn_MR_MACRAW mode
+    @details 0 : disable IPv6 Blocking\n
+    1 : enable IPv6 Blocking\n
+    This bit is applied only during MACRAW mode (P[3:0] = 100. It blocks to receiving the IPv6 packet.
+*/
+#define Sn_MR_MIP6B                  Sn_MR_UCASTB
+
+/* Sn_MR value used with Sn_MR_UDP & Sn_MR_MULTI */
+/**
+    @brief IGMP version used in UDP mulitcasting
+    @details 0 : disable Multicast Blocking\n
+    1 : enable Multicast Blocking\n
+    This bit is applied only when MACRAW mode(P[3:0] = 100. It blocks to receive the packet with multicast MAC address.
+*/
+#define Sn_MR_MC                     Sn_MR_ND
+
+/* Sn_MR alternate values */
+/**
+    @brief For Berkeley Socket API
+*/
+#define SOCK_STREAM                  Sn_MR_TCP
+
+/**
+    @brief For Berkeley Socket API
+*/
+#define SOCK_DGRAM                   Sn_MR_UDP
+
+
+/* Sn_CR values */
+/**
+    @brief Initialize or open socket
+    @details Socket n is initialized and opened according to the protocol selected in Sn_MR(P3:P0).
+    The table below shows the value of @ref Sn_SR corresponding to @ref Sn_MR.\n
+    <table>
+     <tr>  <td>\b Sn_MR (P[3:0])</td> <td>\b Sn_SR</td>            		 </tr>
+     <tr>  <td>Sn_MR_CLOSE  (000)</td> <td></td>         	   		 </tr>
+     <tr>  <td>Sn_MR_TCP  (001)</td> <td>SOCK_INIT (0x13)</td>  		 </tr>
+     <tr>  <td>Sn_MR_UDP  (010)</td>  <td>SOCK_UDP (0x22)</td>  		 </tr>
+     <tr>  <td>S0_MR_MACRAW  (100)</td>  <td>SOCK_MACRAW (0x02)</td>  </tr>
+    </table>
+*/
+#define Sn_CR_OPEN                   0x01
+
+/**
+    @brief Wait connection request in TCP mode(Server mode)
+    @details This is valid only in TCP mode (\ref Sn_MR(P3:P0) = \ref Sn_MR_TCP).
+    In this mode, Socket n operates as a TCP serverand waits for  connection-request (SYN packet) from any TCP client
+    The @ref Sn_SR changes the state from \ref SOCK_INIT to \ref SOCKET_LISTEN.
+    When a TCP clientconnection request is successfully established,
+    the @ref Sn_SR changes from SOCK_LISTEN to SOCK_ESTABLISHED and the @ref Sn_IR(0) becomes
+    But when a TCP clientconnection request is failed, @ref Sn_IR(3) becomes and the status of @ref Sn_SR changes to SOCK_CLOSED.
+*/
+#define Sn_CR_LISTEN                 0x02
+
+/**
+    @brief Send connection request in TCP mode(Client mode)
+    @details  To connect, a connect-request (SYN packet) is sent to <b>TCP server</b>configured by @ref Sn_DIPR & Sn_DPORT(destination address & port).
+    If the connect-request is successful, the @ref Sn_SR is changed to @ref SOCK_ESTABLISHED and the Sn_IR(0) becomes \n\n
+    The connect-request fails in the following three cases.\n
+    1. When a @b ARPTO occurs (@ref Sn_IR[3] =  ) because destination hardware address is not acquired through the ARP-process.\n
+    2. When a @b SYN/ACK packet is not received and @b TCPTO (Sn_IR(3) =  )\n
+    3. When a @b RST packet is received instead of a @b SYN/ACK packet. In these cases, @ref Sn_SR is changed to @ref SOCK_CLOSED.
+    @note This is valid only in TCP mode and operates when Socket n acts as <b>TCP client</b>
+*/
+#define Sn_CR_CONNECT                0x04
+
+/**
+    @brief Send closing request in TCP mode
+    @details Regardless of <b>TCP server</b>or <b>TCP client</b> the DISCON command processes the disconnect-process (b>Active close</b>or <b>Passive close</b>.\n
+    @par Active close
+    it transmits disconnect-request(FIN packet) to the connected peer\n
+    @par Passive close
+    When FIN packet is received from peer, a FIN packet is replied back to the peer.\n
+    @details When the disconnect-process is successful (that is, FIN/ACK packet is received successfully), @ref Sn_SR is changed to @ref SOCK_CLOSED.\n
+    Otherwise, TCPTO occurs (\ref Sn_IR(3)='1') and then @ref Sn_SR is changed to @ref SOCK_CLOSED.
+    @note Valid only in TCP mode.
+*/
+#define Sn_CR_DISCON                 0x08
+
+/**
+    @brief Close socket
+    @details Sn_SR is changed to @ref SOCK_CLOSED.
+*/
+#define Sn_CR_CLOSE                  0x10
+
+/**
+    @brief Update TX buffer pointer and send data
+    @details SEND transmits all the data in the Socket n TX buffer.\n
+    For more details, please refer to Socket n TX Free Size Register (@ref Sn_TX_FSR), Socket n,
+    TX Write Pointer Register(@ref Sn_TX_WR), and Socket n TX Read Pointer Register(@ref Sn_TX_RD).
+*/
+#define Sn_CR_SEND                   0x20
+
+/**
+    @brief Send data with MAC address, so without ARP process
+    @details The basic operation is same as SEND.\n
+    Normally SEND transmits data after destination hardware address is acquired by the automatic ARP-process(Address Resolution Protocol).\n
+    But SEND_MAC transmits data without the automatic ARP-process.\n
+    In this case, the destination hardware address is acquired from @ref Sn_DHAR configured by host, instead of APR-process.
+    @note Valid only in UDP mode.
+*/
+#define Sn_CR_SEND_MAC               0x21
+
+/**
+    @brief Send keep alive message
+    @details It checks the connection status by sending 1byte keep-alive packet.\n
+    If the peer can not respond to the keep-alive packet during timeout time, the connection is terminated and the timeout interrupt will occur.
+    @note Valid only in TCP mode.
+*/
+#define Sn_CR_SEND_KEEP              0x22
+
+/**
+    @brief Update RX buffer pointer and receive data
+    @details RECV completes the processing of the received data in Socket n RX Buffer by using a RX read pointer register (@ref Sn_RX_RD).\n
+    For more details, refer to Socket n RX Received Size Register (@ref Sn_RX_RSR), Socket n RX Write Pointer Register (@ref Sn_RX_WR),
+    and Socket n RX Read Pointer Register (@ref Sn_RX_RD).
+*/
+#define Sn_CR_RECV                   0x40
+
+/* Sn_IR values */
+/**
+    @brief SEND_OK Interrupt
+    @details This is issued when SEND command is completed.
+*/
+#define Sn_IR_SENDOK                 0x10
+
+/**
+    @brief TIMEOUT Interrupt
+    @details This is issued when ARPTO or TCPTO occurs.
+*/
+#define Sn_IR_TIMEOUT                0x08
+
+/**
+    @brief RECV Interrupt
+    @details This is issued whenever data is received from a peer.
+*/
+#define Sn_IR_RECV                   0x04
+
+/**
+    @brief DISCON Interrupt
+    @details This is issued when FIN or FIN/ACK packet is received from a peer.
+*/
+#define Sn_IR_DISCON                 0x02
+
+/**
+    @brief CON Interrupt
+    @details This is issued one time when the connection with peer is successful and then @ref Sn_SR is changed to @ref SOCK_ESTABLISHED.
+*/
+#define Sn_IR_CON                    0x01
+
+/* Sn_SR values */
+/**
+    @brief Closed
+    @details This indicates that Socket n is released.\n
+    When DICON, CLOSE command is ordered, or when a timeout occurs, it is changed to @ref SOCK_CLOSED regardless of previous status.
+*/
+#define SOCK_CLOSED                  0x00
+
+/**
+    @brief Initiate state
+    @details This indicates Socket n is opened with TCP mode.\n
+    It is changed to @ref SOCK_INIT when @ref Sn_MR(P[3:0]) = 001 and OPEN command is ordered.\n
+    After @ref SOCK_INIT, user can use LISTEN /CONNECT command.
+*/
+#define SOCK_INIT                    0x13
+
+/**
+    @brief Listen state
+    @details This indicates Socket n is operating as <b>TCP server</b>mode and waiting for connection-request (SYN packet) from a peer <b>TCP client</b>.\n
+    It will change to @ref SOCK_ESTALBLISHED when the connection-request is successfully accepted.\n
+    Otherwise it will change to @ref SOCK_CLOSED after TCPTO @ref Sn_IR(TIMEOUT) = '1') is occurred.
+*/
+#define SOCK_LISTEN                  0x14
+
+/**
+    @brief Connection state
+    @details This indicates Socket n sent the connect-request packet (SYN packet) to a peer.\n
+    It is temporarily shown when @ref Sn_SR is changed from @ref SOCK_INIT to @ref SOCK_ESTABLISHED by CONNECT command.\n
+    If connect-accept(SYN/ACK packet) is received from the peer at SOCK_SYNSENT, it changes to @ref SOCK_ESTABLISHED.\n
+    Otherwise, it changes to @ref SOCK_CLOSED after TCPTO (@ref Sn_IR[TIMEOUT] = '1') is occurred.
+*/
+#define SOCK_SYNSENT                 0x15
+
+/**
+    @brief Connection state
+    @details It indicates Socket n successfully received the connect-request packet (SYN packet) from a peer.\n
+    If socket n sends the response (SYN/ACK  packet) to the peer successfully,  it changes to @ref SOCK_ESTABLISHED. \n
+    If not, it changes to @ref SOCK_CLOSED after timeout (@ref Sn_IR[TIMEOUT] = '1') is occurred.
+*/
+#define SOCK_SYNRECV                 0x16
+
+/**
+    @brief Success to connect
+    @details This indicates the status of the connection of Socket n.\n
+    It changes to @ref SOCK_ESTABLISHED when the <b>TCP SERVER</b>processed the SYN packet from the <b>TCP CLIENT</b>during @ref SOCK_LISTEN, or
+    when the CONNECT command is successful.\n
+    During @ref SOCK_ESTABLISHED, DATA packet can be transferred using SEND or RECV command.
+*/
+#define SOCK_ESTABLISHED             0x17
+
+/**
+    @brief Closing state
+    @details These indicate Socket n is closing.\n
+    These are shown in disconnect-process such as active-close and passive-close.\n
+    When Disconnect-process is successfully completed, or when timeout occurs, these change to @ref SOCK_CLOSED.
+*/
+#define SOCK_FIN_WAIT                0x18
+
+/**
+    @brief Closing state
+    @details These indicate Socket n is closing.\n
+    These are shown in disconnect-process such as active-close and passive-close.\n
+    When Disconnect-process is successfully completed, or when timeout occurs, these change to @ref SOCK_CLOSED.
+*/
+#define SOCK_CLOSING                 0x1A
+
+/**
+    @brief Closing state
+    @details These indicate Socket n is closing.\n
+    These are shown in disconnect-process such as active-close and passive-close.\n
+    When Disconnect-process is successfully completed, or when timeout occurs, these change to @ref SOCK_CLOSED.
+*/
+#define SOCK_TIME_WAIT               0x1B
+
+/**
+    @brief Closing state
+    @details This indicates Socket n received the disconnect-request (FIN packet) from the connected peer.\n
+    This is half-closing status, and data can be transferred.\n
+    For full-closing, DISCON command is used. But For just-closing, CLOSE command is used.
+*/
+#define SOCK_CLOSE_WAIT              0x1C
+
+/**
+    @brief Closing state
+    @details This indicates Socket n is waiting for the response (FIN/ACK packet) to the disconnect-request (FIN packet) by passive-close.\n
+    It changes to @ref SOCK_CLOSED when Socket n received the response successfully, or when timeout(@ref Sn_IR[TIMEOUT] = '1') is occurred.
+*/
+#define SOCK_LAST_ACK                0x1D
+
+/**
+    @brief UDP socket
+    @details This indicates Socket n is opened in UDP mode(@ref Sn_MR(P[3:0]) = '010').\n
+    It changes to SOCK_UDP when @ref Sn_MR(P[3:0]) = '010' and @ref Sn_CR_OPEN command is ordered.\n
+    Unlike TCP mode, data can be transfered without the connection-process.
+*/
+#define SOCK_UDP                     0x22
+
+#define SOCK_IPRAW                   0x32     /**< IP raw mode socket */
+
+/**
+    @brief MAC raw mode socket
+    @details This indicates Socket 0 is opened in MACRAW mode (S0_MR(P[3:0]) = 100and is valid only in Socket 0.\n
+    It changes to SOCK_MACRAW when S0_MR(P[3:0] = 100and OPEN command is ordered.\n
+    Like UDP mode socket, MACRAW mode Socket 0 can transfer a MAC packet (Ethernet frame) without the connection-process.
+*/
+#define SOCK_MACRAW                  0x42
+
+//#define SOCK_PPPOE                   0x5F
+
+/* IP PROTOCOL */
+#define IPPROTO_IP                   0        //< Dummy for IP 
+#define IPPROTO_ICMP                 1        //< Control message protocol
+#define IPPROTO_IGMP                 2        //< Internet group management protocol
+#define IPPROTO_GGP                  3        //< Gateway^2 (deprecated)
+#define IPPROTO_TCP                  6        //< TCP
+#define IPPROTO_PUP                  12       //< PUP
+#define IPPROTO_UDP                  17       //< UDP
+#define IPPROTO_IDP                  22       //< XNS idp
+#define IPPROTO_ND                   77       //< UNOFFICIAL net disk protocol
+#define IPPROTO_RAW                  255      //< Raw IP packet
+
+
+/**
+    @brief Enter a critical section
+
+    @details It is provided to protect your shared code which are executed without distribution. \n \n
+
+    In non-OS environment, It can be just implemented by disabling whole interrupt.\n
+    In OS environment, You can replace it to critical section api supported by OS.
+
+    \sa WIZCHIP_READ(), WIZCHIP_WRITE(), WIZCHIP_READ_BUF(), WIZCHIP_WRITE_BUF()
+    \sa WIZCHIP_CRITICAL_EXIT()
+*/
+#define WIZCHIP_CRITICAL_ENTER()    WIZCHIP.CRIS._enter()
+
+#ifdef _exit
+#undef _exit
+#endif
+
+/**
+    @brief Exit a critical section
+
+    @details It is provided to protect your shared code which are executed without distribution. \n\n
+
+    In non-OS environment, It can be just implemented by disabling whole interrupt. \n
+    In OS environment, You can replace it to critical section api supported by OS.
+
+    @sa WIZCHIP_READ(), WIZCHIP_WRITE(), WIZCHIP_READ_BUF(), WIZCHIP_WRITE_BUF()
+    @sa WIZCHIP_CRITICAL_ENTER()
+*/
+#define WIZCHIP_CRITICAL_EXIT()     WIZCHIP.CRIS._exit()
+
+
+////////////////////////
+// Basic I/O Function //
+////////////////////////
+
+/**
+    @ingroup Basic_IO_function
+    @brief It reads 1 byte value from a register.
+    @param AddrSel Register address
+    @return The value of register
+*/
+uint8_t  WIZCHIP_READ(uint32_t AddrSel);
+
+/**
+    @ingroup Basic_IO_function
+    @brief It writes 1 byte value to a register.
+    @param AddrSel Register address
+    @param wb Write data
+    @return void
+*/
+void     WIZCHIP_WRITE(uint32_t AddrSel, uint8_t wb);
+
+/**
+    @ingroup Basic_IO_function
+    @brief It reads sequence data from registers.
+    @param AddrSel Register address
+    @param pBuf Pointer buffer to read data
+    @param len Data length
+*/
+void     WIZCHIP_READ_BUF(uint32_t AddrSel, uint8_t* pBuf, uint16_t len);
+
+/**
+    @ingroup Basic_IO_function
+    @brief It writes sequence data to registers.
+    @param AddrSel Register address
+    @param pBuf Pointer buffer to write data
+    @param len Data length
+*/
+void     WIZCHIP_WRITE_BUF(uint32_t AddrSel, uint8_t* pBuf, uint16_t len);
+
+/////////////////////////////////
+// Common Register I/O function //
+/////////////////////////////////
+/**
+    @ingroup Common_register_access_function
+    @brief Set Mode Register
+    @param (uint8_t)mr The value to be set.
+    @sa getMR()
+*/
+#define setMR(mr) \
+	WIZCHIP_WRITE(MR,mr)
+
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get Mode Register
+    @return uint8_t. The value of Mode register.
+    @sa setMR()
+*/
+#define getMR() \
+		WIZCHIP_READ(MR)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set gateway IP address
+    @param (uint8_t*)gar Pointer variable to set gateway IP address. It should be allocated 4 bytes.
+    @sa getGAR()
+*/
+#define setGAR(gar) \
+		WIZCHIP_WRITE_BUF(GAR,gar,4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get gateway IP address
+    @param (uint8_t*)gar Pointer variable to get gateway IP address. It should be allocated 4 bytes.
+    @sa setGAR()
+*/
+#define getGAR(gar) \
+		WIZCHIP_READ_BUF(GAR,gar,4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set subnet mask address
+    @param (uint8_t*)subr Pointer variable to set subnet mask address. It should be allocated 4 bytes.
+    @sa getSUBR()
+*/
+#define setSUBR(subr) \
+		WIZCHIP_WRITE_BUF(SUBR, subr,4)
+
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get subnet mask address
+    @param (uint8_t*)subr Pointer variable to get subnet mask address. It should be allocated 4 bytes.
+    @sa setSUBR()
+*/
+#define getSUBR(subr) \
+		WIZCHIP_READ_BUF(SUBR, subr, 4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set local MAC address
+    @param (uint8_t*)shar Pointer variable to set local MAC address. It should be allocated 6 bytes.
+    @sa getSHAR()
+*/
+#define setSHAR(shar) \
+		WIZCHIP_WRITE_BUF(SHAR, shar, 6)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get local MAC address
+    @param (uint8_t*)shar Pointer variable to get local MAC address. It should be allocated 6 bytes.
+    @sa setSHAR()
+*/
+#define getSHAR(shar) \
+		WIZCHIP_READ_BUF(SHAR, shar, 6)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set local IP address
+    @param (uint8_t*)sipr Pointer variable to set local IP address. It should be allocated 4 bytes.
+    @sa getSIPR()
+*/
+#define setSIPR(sipr) \
+		WIZCHIP_WRITE_BUF(SIPR, sipr, 4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get local IP address
+    @param (uint8_t*)sipr Pointer variable to get local IP address. It should be allocated 4 bytes.
+    @sa setSIPR()
+*/
+#define getSIPR(sipr) \
+		WIZCHIP_READ_BUF(SIPR, sipr, 4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set INTLEVEL register
+    @param (uint16_t)intlevel Value to set @ref INTLEVEL register.
+    @sa getINTLEVEL()
+*/
+#define setINTLEVEL(intlevel)  {\
+		WIZCHIP_WRITE(INTLEVEL,   (uint8_t)(intlevel >> 8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(INTLEVEL,1), (uint8_t) intlevel); \
+	}
+
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get INTLEVEL register
+    @return uint16_t. Value of @ref INTLEVEL register.
+    @sa setINTLEVEL()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getINTLEVEL() \
+		((WIZCHIP_READ(INTLEVEL) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(INTLEVEL,1)))
+*/
+#define getINTLEVEL() \
+		(((uint16_t)WIZCHIP_READ(INTLEVEL) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(INTLEVEL,1)))
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref IR register
+    @param (uint8_t)ir Value to set @ref IR register.
+    @sa getIR()
+*/
+#define setIR(ir) \
+		WIZCHIP_WRITE(IR, (ir & 0xF0))
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref IR register
+    @return uint8_t. Value of @ref IR register.
+    @sa setIR()
+*/
+#define getIR() \
+		(WIZCHIP_READ(IR) & 0xF0)
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref _IMR_ register
+    @param (uint8_t)imr Value to set @ref _IMR_ register.
+    @sa getIMR()
+*/
+#define setIMR(imr) \
+		WIZCHIP_WRITE(_IMR_, imr)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref _IMR_ register
+    @return uint8_t. Value of @ref _IMR_ register.
+    @sa setIMR()
+*/
+#define getIMR() \
+		WIZCHIP_READ(_IMR_)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref SIR register
+    @param (uint8_t)sir Value to set @ref SIR register.
+    @sa getSIR()
+*/
+#define setSIR(sir) \
+		WIZCHIP_WRITE(SIR, sir)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref SIR register
+    @return uint8_t. Value of @ref SIR register.
+    @sa setSIR()
+*/
+#define getSIR() \
+		WIZCHIP_READ(SIR)
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref SIMR register
+    @param (uint8_t)simr Value to set @ref SIMR register.
+    @sa getSIMR()
+*/
+#define setSIMR(simr) \
+		WIZCHIP_WRITE(SIMR, simr)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref SIMR register
+    @return uint8_t. Value of @ref SIMR register.
+    @sa setSIMR()
+*/
+#define getSIMR() \
+		WIZCHIP_READ(SIMR)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref _RTR_ register
+    @param (uint16_t)rtr Value to set @ref _RTR_ register.
+    @sa getRTR()
+*/
+#define setRTR(rtr)   {\
+		WIZCHIP_WRITE(_RTR_,   (uint8_t)(rtr >> 8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(_RTR_,1), (uint8_t) rtr); \
+	}
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref _RTR_ register
+    @return uint16_t. Value of @ref _RTR_ register.
+    @sa setRTR()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getRTR() \
+		((WIZCHIP_READ(_RTR_) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(_RTR_,1)))
+*/
+#define getRTR() \
+		(((uint16_t)WIZCHIP_READ(_RTR_) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(_RTR_,1)))
+
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref _RCR_ register
+    @param (uint8_t)rcr Value to set @ref _RCR_ register.
+    @sa getRCR()
+*/
+#define setRCR(rcr) \
+		WIZCHIP_WRITE(_RCR_, rcr)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref _RCR_ register
+    @return uint8_t. Value of @ref _RCR_ register.
+    @sa setRCR()
+*/
+#define getRCR() \
+		WIZCHIP_READ(_RCR_)
+
+//================================================== test done ===========================================================
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PTIMER register
+    @param (uint8_t)ptimer Value to set @ref PTIMER register.
+    @sa getPTIMER()
+*/
+#define setPTIMER(ptimer) \
+		WIZCHIP_WRITE(PTIMER, ptimer)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PTIMER register
+    @return uint8_t. Value of @ref PTIMER register.
+    @sa setPTIMER()
+*/
+#define getPTIMER() \
+		WIZCHIP_READ(PTIMER)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PMAGIC register
+    @param (uint8_t)pmagic Value to set @ref PMAGIC register.
+    @sa getPMAGIC()
+*/
+#define setPMAGIC(pmagic) \
+		WIZCHIP_WRITE(PMAGIC, pmagic)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PMAGIC register
+    @return uint8_t. Value of @ref PMAGIC register.
+    @sa setPMAGIC()
+*/
+#define getPMAGIC() \
+		WIZCHIP_READ(PMAGIC)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PHAR address
+    @param (uint8_t*)phar Pointer variable to set PPP destination MAC register address. It should be allocated 6 bytes.
+    @sa getPHAR()
+*/
+#define setPHAR(phar) \
+		WIZCHIP_WRITE_BUF(PHAR, phar, 6)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PHAR address
+    @param (uint8_t*)phar Pointer variable to PPP destination MAC register address. It should be allocated 6 bytes.
+    @sa setPHAR()
+*/
+#define getPHAR(phar) \
+		WIZCHIP_READ_BUF(PHAR, phar, 6)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PSID register
+    @param (uint16_t)psid Value to set @ref PSID register.
+    @sa getPSID()
+*/
+#define setPSID(psid)  {\
+		WIZCHIP_WRITE(PSID,   (uint8_t)(psid >> 8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(PSID,1), (uint8_t) psid); \
+	}
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PSID register
+    @return uint16_t. Value of @ref PSID register.
+    @sa setPSID()
+*/
+//uint16_t getPSID(void);
+//M20150401 : Type explict declaration
+/*
+    #define getPSID() \
+		((WIZCHIP_READ(PSID) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(PSID,1)))
+*/
+#define getPSID() \
+		(((uint16_t)WIZCHIP_READ(PSID) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(PSID,1)))
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PMRU register
+    @param (uint16_t)pmru Value to set @ref PMRU register.
+    @sa getPMRU()
+*/
+#define setPMRU(pmru) { \
+		WIZCHIP_WRITE(PMRU,   (uint8_t)(pmru>>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(PMRU,1), (uint8_t) pmru); \
+	}
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PMRU register
+    @return uint16_t. Value of @ref PMRU register.
+    @sa setPMRU()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getPMRU() \
+		((WIZCHIP_READ(PMRU) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(PMRU,1)))
+*/
+#define getPMRU() \
+		(((uint16_t)WIZCHIP_READ(PMRU) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(PMRU,1)))
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get unreachable IP address
+    @param (uint8_t*)uipr Pointer variable to get unreachable IP address. It should be allocated 4 bytes.
+*/
+//M20150401 : Size Error of UIPR (6 -> 4)
+/*
+    #define getUIPR(uipr) \
+		WIZCHIP_READ_BUF(UIPR,uipr,6)
+*/
+#define getUIPR(uipr) \
+		WIZCHIP_READ_BUF(UIPR,uipr,4)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref UPORTR register
+    @return uint16_t. Value of @ref UPORTR register.
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getUPORTR() \
+	((WIZCHIP_READ(UPORTR) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(UPORTR,1)))
+*/
+#define getUPORTR() \
+	(((uint16_t)WIZCHIP_READ(UPORTR) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(UPORTR,1)))
+
+/**
+    @ingroup Common_register_access_function
+    @brief Set @ref PHYCFGR register
+    @param (uint8_t)phycfgr Value to set @ref PHYCFGR register.
+    @sa getPHYCFGR()
+*/
+#define setPHYCFGR(phycfgr) \
+		WIZCHIP_WRITE(PHYCFGR, phycfgr)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref PHYCFGR register
+    @return uint8_t. Value of @ref PHYCFGR register.
+    @sa setPHYCFGR()
+*/
+#define getPHYCFGR() \
+		WIZCHIP_READ(PHYCFGR)
+
+/**
+    @ingroup Common_register_access_function
+    @brief Get @ref VERSIONR register
+    @return uint8_t. Value of @ref VERSIONR register.
+*/
+#define getVERSIONR() \
+		WIZCHIP_READ(VERSIONR)
+
+/////////////////////////////////////
+
+///////////////////////////////////
+// Socket N register I/O function //
+///////////////////////////////////
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_MR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)mr Value to set @ref Sn_MR
+    @sa getSn_MR()
+*/
+#define setSn_MR(sn, mr) \
+		WIZCHIP_WRITE(Sn_MR(sn),mr)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_MR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_MR.
+    @sa setSn_MR()
+*/
+#define getSn_MR(sn) \
+	WIZCHIP_READ(Sn_MR(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_CR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)cr Value to set @ref Sn_CR
+    @sa getSn_CR()
+*/
+#define setSn_CR(sn, cr) \
+		WIZCHIP_WRITE(Sn_CR(sn), cr)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_CR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_CR.
+    @sa setSn_CR()
+*/
+#define getSn_CR(sn) \
+		WIZCHIP_READ(Sn_CR(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_IR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)ir Value to set @ref Sn_IR
+    @sa getSn_IR()
+*/
+#define setSn_IR(sn, ir) \
+		WIZCHIP_WRITE(Sn_IR(sn), (ir & 0x1F))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_IR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_IR.
+    @sa setSn_IR()
+*/
+#define getSn_IR(sn) \
+		(WIZCHIP_READ(Sn_IR(sn)) & 0x1F)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_IMR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)imr Value to set @ref Sn_IMR
+    @sa getSn_IMR()
+*/
+#define setSn_IMR(sn, imr) \
+		WIZCHIP_WRITE(Sn_IMR(sn), (imr & 0x1F))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_IMR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_IMR.
+    @sa setSn_IMR()
+*/
+#define getSn_IMR(sn) \
+		(WIZCHIP_READ(Sn_IMR(sn)) & 0x1F)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_SR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_SR.
+*/
+#define getSn_SR(sn) \
+		WIZCHIP_READ(Sn_SR(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_PORT register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)port Value to set @ref Sn_PORT.
+    @sa getSn_PORT()
+*/
+#define setSn_PORT(sn, port)  { \
+		WIZCHIP_WRITE(Sn_PORT(sn),   (uint8_t)(port >> 8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_PORT(sn),1), (uint8_t) port); \
+	}
+#define setSn_PORTR  setSn_PORT
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_PORT register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_PORT.
+    @sa setSn_PORT()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_PORT(sn) \
+		((WIZCHIP_READ(Sn_PORT(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_PORT(sn),1)))
+*/
+#define getSn_PORT(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_PORT(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_PORT(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_DHAR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t*)dhar Pointer variable to set socket n destination hardware address. It should be allocated 6 bytes.
+    @sa getSn_DHAR()
+*/
+#define setSn_DHAR(sn, dhar) \
+		WIZCHIP_WRITE_BUF(Sn_DHAR(sn), dhar, 6)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_MR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t*)dhar Pointer variable to get socket n destination hardware address. It should be allocated 6 bytes.
+    @sa setSn_DHAR()
+*/
+#define getSn_DHAR(sn, dhar) \
+		WIZCHIP_READ_BUF(Sn_DHAR(sn), dhar, 6)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_DIPR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t*)dipr Pointer variable to set socket n destination IP address. It should be allocated 4 bytes.
+    @sa getSn_DIPR()
+*/
+#define setSn_DIPR(sn, dipr) \
+		WIZCHIP_WRITE_BUF(Sn_DIPR(sn), dipr, 4)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_DIPR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t*)dipr Pointer variable to get socket n destination IP address. It should be allocated 4 bytes.
+    @sa setSn_DIPR()
+*/
+#define getSn_DIPR(sn, dipr) \
+		WIZCHIP_READ_BUF(Sn_DIPR(sn), dipr, 4)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_DPORT register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)dport Value to set @ref Sn_DPORT
+    @sa getSn_DPORT()
+*/
+#define setSn_DPORT(sn, dport) { \
+		WIZCHIP_WRITE(Sn_DPORT(sn),   (uint8_t) (dport>>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_DPORT(sn),1), (uint8_t)  dport); \
+	}
+#define setSn_DPORTR(sn, dport)   setSn_DPORT(sn,dport) ///< For compatible ioLibrary. Refer to @ref Sn_DPORTR.
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_DPORT register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_DPORT.
+    @sa setSn_DPORT()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_DPORT(sn) \
+		((WIZCHIP_READ(Sn_DPORT(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_DPORT(sn),1)))
+*/
+#define getSn_DPORT(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_DPORT(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_DPORT(sn),1)))
+#define getSn_DPORTR(sn)  getSn_DPORT(sn)
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_MSSR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)mss Value to set @ref Sn_MSSR
+    @sa setSn_MSSR()
+*/
+#define setSn_MSSR(sn, mss) { \
+		WIZCHIP_WRITE(Sn_MSSR(sn),   (uint8_t)(mss>>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_MSSR(sn),1), (uint8_t) mss); \
+	}
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_MSSR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_MSSR.
+    @sa setSn_MSSR()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_MSSR(sn) \
+		((WIZCHIP_READ(Sn_MSSR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_MSSR(sn),1)))
+*/
+#define getSn_MSSR(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_MSSR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_MSSR(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_TOS register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)tos Value to set @ref Sn_TOS
+    @sa getSn_TOS()
+*/
+#define setSn_TOS(sn, tos) \
+		WIZCHIP_WRITE(Sn_TOS(sn), tos)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TOS register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of Sn_TOS.
+    @sa setSn_TOS()
+*/
+#define getSn_TOS(sn) \
+		WIZCHIP_READ(Sn_TOS(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_TTL register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)ttl Value to set @ref Sn_TTL
+    @sa getSn_TTL()
+*/
+#define setSn_TTL(sn, ttl) \
+		WIZCHIP_WRITE(Sn_TTL(sn), ttl)
+
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TTL register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_TTL.
+    @sa setSn_TTL()
+*/
+#define getSn_TTL(sn) \
+		WIZCHIP_READ(Sn_TTL(sn))
+
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_RXBUF_SIZE register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)rxbufsize Value to set @ref Sn_RXBUF_SIZE
+    @sa getSn_RXBUF_SIZE()
+*/
+#define setSn_RXBUF_SIZE(sn, rxbufsize) \
+		WIZCHIP_WRITE(Sn_RXBUF_SIZE(sn),rxbufsize)
+
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_RXBUF_SIZE register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_RXBUF_SIZE.
+    @sa setSn_RXBUF_SIZE()
+*/
+#define getSn_RXBUF_SIZE(sn) \
+		WIZCHIP_READ(Sn_RXBUF_SIZE(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_TXBUF_SIZE register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)txbufsize Value to set @ref Sn_TXBUF_SIZE
+    @sa getSn_TXBUF_SIZE()
+*/
+#define setSn_TXBUF_SIZE(sn, txbufsize) \
+		WIZCHIP_WRITE(Sn_TXBUF_SIZE(sn), txbufsize)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TXBUF_SIZE register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_TXBUF_SIZE.
+    @sa setSn_TXBUF_SIZE()
+*/
+#define getSn_TXBUF_SIZE(sn) \
+		WIZCHIP_READ(Sn_TXBUF_SIZE(sn))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TX_FSR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_TX_FSR.
+*/
+uint16_t getSn_TX_FSR(uint8_t sn);
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TX_RD register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_TX_RD.
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_TX_RD(sn) \
+		((WIZCHIP_READ(Sn_TX_RD(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_RD(sn),1)))
+*/
+#define getSn_TX_RD(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_TX_RD(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_RD(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_TX_WR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)txwr Value to set @ref Sn_TX_WR
+    @sa GetSn_TX_WR()
+*/
+#define setSn_TX_WR(sn, txwr) { \
+		WIZCHIP_WRITE(Sn_TX_WR(sn),   (uint8_t)(txwr>>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_TX_WR(sn),1), (uint8_t) txwr); \
+		}
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_TX_WR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_TX_WR.
+    @sa setSn_TX_WR()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_TX_WR(sn) \
+		((WIZCHIP_READ(Sn_TX_WR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_WR(sn),1)))
+*/
+#define getSn_TX_WR(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_TX_WR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_TX_WR(sn),1)))
+
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_RX_RSR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_RX_RSR.
+*/
+uint16_t getSn_RX_RSR(uint8_t sn);
+
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_RX_RD register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)rxrd Value to set @ref Sn_RX_RD
+    @sa getSn_RX_RD()
+*/
+#define setSn_RX_RD(sn, rxrd) { \
+		WIZCHIP_WRITE(Sn_RX_RD(sn),   (uint8_t)(rxrd>>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_RX_RD(sn),1), (uint8_t) rxrd); \
+	}
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_RX_RD register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_RX_RD.
+    @sa setSn_RX_RD()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_RX_RD(sn) \
+		((WIZCHIP_READ(Sn_RX_RD(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_RD(sn),1)))
+*/
+#define getSn_RX_RD(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_RX_RD(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_RD(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_RX_WR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_RX_WR.
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_RX_WR(sn) \
+		((WIZCHIP_READ(Sn_RX_WR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_WR(sn),1)))
+*/
+#define getSn_RX_WR(sn) \
+		(((uint16_t)WIZCHIP_READ(Sn_RX_WR(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_RX_WR(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_FRAG register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint16_t)frag Value to set @ref Sn_FRAG
+    @sa getSn_FRAD()
+*/
+#define setSn_FRAG(sn, frag) { \
+		WIZCHIP_WRITE(Sn_FRAG(sn),  (uint8_t)(frag >>8)); \
+		WIZCHIP_WRITE(WIZCHIP_OFFSET_INC(Sn_FRAG(sn),1), (uint8_t) frag); \
+	}
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_FRAG register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of @ref Sn_FRAG.
+    @sa setSn_FRAG()
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_FRAG(sn) \
+		((WIZCHIP_READ(Sn_FRAG(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_FRAG(sn),1)))
+*/
+#define getSn_FRAG(sn) \
+      (((uint16_t)WIZCHIP_READ(Sn_FRAG(sn)) << 8) + WIZCHIP_READ(WIZCHIP_OFFSET_INC(Sn_FRAG(sn),1)))
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Set @ref Sn_KPALVTR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param (uint8_t)kpalvt Value to set @ref Sn_KPALVTR
+    @sa getSn_KPALVTR()
+*/
+#define setSn_KPALVTR(sn, kpalvt) \
+		WIZCHIP_WRITE(Sn_KPALVTR(sn), kpalvt)
+
+/**
+    @ingroup Socket_register_access_function
+    @brief Get @ref Sn_KPALVTR register
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint8_t. Value of @ref Sn_KPALVTR.
+    @sa setSn_KPALVTR()
+*/
+#define getSn_KPALVTR(sn) \
+		WIZCHIP_READ(Sn_KPALVTR(sn))
+
+//////////////////////////////////////
+
+/////////////////////////////////////
+// Sn_TXBUF & Sn_RXBUF IO function //
+/////////////////////////////////////
+/**
+    @brief Socket_register_access_function
+    @brief Gets the max buffer size of socket sn passed as parameter.
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of Socket n RX max buffer size.
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_RxMAX(sn) \
+		(getSn_RXBUF_SIZE(sn) << 10)
+*/
+#define getSn_RxMAX(sn) \
+		(((uint16_t)getSn_RXBUF_SIZE(sn)) << 10)
+
+/**
+    @brief Socket_register_access_function
+    @brief Gets the max buffer size of socket sn passed as parameters.
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @return uint16_t. Value of Socket n TX max buffer size.
+*/
+//M20150401 : Type explict declaration
+/*
+    #define getSn_TxMAX(sn) \
+		(getSn_TXBUF_SIZE(sn) << 10)
+*/
+#define getSn_TxMAX(sn) \
+		(((uint16_t)getSn_TXBUF_SIZE(sn)) << 10)
+
+/**
+    @ingroup Basic_IO_function
+    @brief It copies data to internal TX memory
+
+    @details This function reads the Tx write pointer register and after that,
+    it copies the <i>wizdata(pointer buffer)</i> of the length of <i>len(variable)</i> bytes to internal TX memory
+    and updates the Tx write pointer register.
+    This function is being called by send() and sendto() function also.
+
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param wizdata Pointer buffer to write data
+    @param len Data length
+    @sa wiz_recv_data()
+*/
+void wiz_send_data(uint8_t sn, uint8_t *wizdata, uint16_t len);
+
+/**
+    @ingroup Basic_IO_function
+    @brief It copies data to your buffer from internal RX memory
+
+    @details This function read the Rx read pointer register and after that,
+    it copies the received data from internal RX memory
+    to <i>wizdata(pointer variable)</i> of the length of <i>len(variable)</i> bytes.
+    This function is being called by recv() also.
+
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param wizdata Pointer buffer to read data
+    @param len Data length
+    @sa wiz_send_data()
+*/
+void wiz_recv_data(uint8_t sn, uint8_t *wizdata, uint16_t len);
+
+/**
+    @ingroup Basic_IO_function
+    @brief It discard the received data in RX memory.
+    @details It discards the data of the length of <i>len(variable)</i> bytes in internal RX memory.
+    @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
+    @param len Data length
+*/
+void wiz_recv_ignore(uint8_t sn, uint16_t len);
+
+/// @cond DOXY_APPLY_CODE
+#endif
+/// @endcond
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif   // _W5500_H_

--- a/third_party/ioLibrary_Driver/Ethernet/socket.c
+++ b/third_party/ioLibrary_Driver/Ethernet/socket.c
@@ -1,0 +1,1473 @@
+//*****************************************************************************
+//
+//! \file socket.c
+//! \brief SOCKET APIs Implements file.
+//! \details SOCKET APIs like as Berkeley Socket APIs.
+//! \version 1.0.3
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2014/05/01> V1.0.3. Refer to M20140501
+//!         1. Implicit type casting -> Explicit type casting.
+//!         2. replace 0x01 with PACK_REMAINED in recvfrom()
+//!         3. Validation a destination ip in connect() & sendto():
+//!            It occurs a fatal error on converting unint32 address if uint8* addr parameter is not aligned by 4byte address.
+//!            Copy 4 byte addr value into temporary uint32 variable and then compares it.
+//!       <2013/12/20> V1.0.2 Refer to M20131220
+//!                    Remove Warning.
+//!       <2013/11/04> V1.0.1 2nd Release. Refer to "20131104".
+//!                    In sendto(), Add to clear timeout interrupt status (Sn_IR_TIMEOUT)
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+#include "socket.h"
+
+//M20150401 : Typing Error
+//#define SOCK_ANY_PORT_NUM  0xC000;
+#define SOCK_ANY_PORT_NUM  0xC000
+
+static uint16_t sock_any_port = SOCK_ANY_PORT_NUM;
+static uint16_t sock_io_mode = 0;
+static uint16_t sock_is_sending = 0;
+
+static uint16_t sock_remained_size[_WIZCHIP_SOCK_NUM_] = {0, 0,};
+
+//M20150601 : For extern decleation
+//static uint8_t  sock_pack_info[_WIZCHIP_SOCK_NUM_] = {0,};
+uint8_t  sock_pack_info[_WIZCHIP_SOCK_NUM_] = {0,};
+//
+
+#if _WIZCHIP_ == 5200
+static uint16_t sock_next_rd[_WIZCHIP_SOCK_NUM_] = {0,};
+#endif
+
+//A20150601 : For integrating with W5300
+#if _WIZCHIP_ == 5300
+uint8_t sock_remained_byte[_WIZCHIP_SOCK_NUM_] = {0,}; // set by wiz_recv_data()
+#endif
+
+
+#define CHECK_SOCKNUM()   \
+   do{                    \
+      if(sn >= _WIZCHIP_SOCK_NUM_) return SOCKERR_SOCKNUM;   \
+   }while(0);             \
+
+#define CHECK_SOCKMODE(mode)  \
+   do{                     \
+      if((getSn_MR(sn) & 0x0F) != mode) return SOCKERR_SOCKMODE;  \
+   }while(0);              \
+
+#define CHECK_TCPMODE()                                           \
+   do{                                                            \
+      if((getSn_MR(sn) & 0x03) != 0x01) return SOCKERR_SOCKMODE;  \
+   }while(0);
+
+#define CHECK_SOCKINIT()   \
+   do{                     \
+      if((getSn_SR(sn) != SOCK_INIT)) return SOCKERR_SOCKINIT; \
+   }while(0);              \
+
+#define CHECK_SOCKDATA()   \
+   do{                     \
+      if(len == 0) return SOCKERR_DATALEN;   \
+   }while(0);              \
+//teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+#define CHECK_TCPMODE()                                           \
+   do{                                                            \
+      if((getSn_MR(sn) & 0x03) != 0x01) return SOCKERR_SOCKMODE;  \
+   }while(0);
+
+#define CHECK_UDPMODE()                                           \
+   do{                                                            \
+      if((getSn_MR(sn) & 0x03) != 0x02) return SOCKERR_SOCKMODE;  \
+   }while(0);
+
+#define CHECK_IPMODE()                                            \
+   do{                                                            \
+      if((getSn_MR(sn) & 0x07) != 0x03) return SOCKERR_SOCKMODE;  \
+   }while(0);
+
+#define CHECK_DGRAMMODE()                                         \
+   do{                                                            \
+      if(getSn_MR(sn) == Sn_MR_CLOSED) return SOCKERR_SOCKMODE;   \
+      if((getSn_MR(sn) & 0x03) == 0x01) return SOCKERR_SOCKMODE;  \
+   }while(0);
+
+#define CHECK_IPZERO(addr, addrlen)                                  \
+   do{                                                               \
+      uint16_t ipzero= 0;                                            \
+      for(uint8_t i=0; i<addrlen; i++)  ipzero += (uint16_t)addr[i]; \
+      if (ipzero == 0) return SOCKERR_IPINVALID;                     \
+   }while(0);
+
+
+#endif
+
+
+#if (_WIZCHIP_ > W5500)
+#define IPV6_AVAILABLE
+#endif
+
+#if 1
+
+
+#define Sn_MR_TCP4           (Sn_MR_TCP)   ///< Refer to @ref Sn_MR_TCP.
+#define Sn_MR_UDP4           (Sn_MR_UDP)   ///< Refer to @ref Sn_MR_UDP
+#define Sn_MR_IPRAW4         (Sn_MR_IPRAW)   ///< Refer to @ref Sn_MR_IPRAW.   
+#define Sn_MR_TCP6           (0x09)
+#define Sn_MR_UDP6           (0x0A) //0x1010
+#define Sn_MR_IPRAW6         (0x0B) //0x1011
+#define Sn_MR_TCPD           (0x0D)
+#define Sn_MR_UDPD           (0x0E)
+
+
+
+#endif
+
+
+#if 0 // By lihan  
+static uint8_t addrlenTEST = -1 ;
+
+void setAddrlen_W6x00(uint8_t num) {
+    addrlenTEST = num;
+}
+
+uint8_t  checkAddrlen_W6x00() {
+    //if (addrlenTEST < 0 )
+    if ((addrlenTEST != 4)  && (addrlenTEST != 16)) {
+        perror("Error: addrlen is not initialized");
+    } else {
+        printf("addrlenTEST %d \r\n", addrlenTEST) ;
+    }
+    return addrlenTEST;
+}
+
+inline void inline_setAddrlen_W6x00(uint8_t num) {
+#if (_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300)
+    setAddrlen_W6x00(num);
+#endif
+}
+
+inline uint8_t inline_CheckAddrlen_W6x00(void) {
+#if (_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300)
+    return  checkAddrlen_W6x00();
+#else
+    return 4;
+#endif
+}
+#endif
+
+
+
+
+int8_t socket(uint8_t sn, uint8_t protocol, uint16_t port, uint8_t flag) {
+
+    uint8_t taddr[16];
+    uint16_t local_port = 0;
+    CHECK_SOCKNUM();
+    switch (protocol & 0x0F) {
+#ifdef IPV6_AVAILABLE
+    case Sn_MR_TCP4 :
+        getSIPR(taddr);
+        CHECK_IPZERO(taddr, 4);
+        break;
+    case Sn_MR_TCP6 :
+        getLLAR(taddr);
+        CHECK_IPZERO(taddr, 16);
+        //getGUAR(taddr);
+        //CHECK_IPZERO(taddr, 16);
+        break;
+    case Sn_MR_TCPD :
+        getSIPR(taddr);
+        CHECK_IPZERO(taddr, 4);
+        getLLAR(taddr);
+        CHECK_IPZERO(taddr, 16);
+        //getGUAR(taddr);
+        //CHECK_IPZERO(taddr, 16);
+        break;
+#else
+    case Sn_MR_TCP : {
+        //M20150601 : Fixed the warning - taddr will never be NULL
+        /*
+            uint8_t taddr[4];
+            getSIPR(taddr);
+        */
+        uint32_t taddr;
+        getSIPR((uint8_t*)&taddr);
+        if (taddr == 0) {
+            return SOCKERR_SOCKINIT;
+        }
+        break;
+    }
+#endif
+    case Sn_MR_UDP :
+    case Sn_MR_UDP6 :
+    case Sn_MR_UDPD :
+    case Sn_MR_MACRAW :
+    case Sn_MR_IPRAW4 :
+    case Sn_MR_IPRAW6 :
+        break;
+#if ( _WIZCHIP_ < 5200 )
+    case Sn_MR_PPPoE :
+        break;
+#endif
+    default :
+        return SOCKERR_SOCKMODE;
+    }
+    //M20150601 : For SF_TCP_ALIGN & W5300
+    //if((flag & 0x06) != 0) return SOCKERR_SOCKFLAG;
+    if ((flag & 0x04) != 0) {
+        return SOCKERR_SOCKFLAG;
+    }
+#if _WIZCHIP_ == 5200
+    if (flag & 0x10) {
+        return SOCKERR_SOCKFLAG;
+    }
+#endif
+
+    if (flag != 0) {
+        switch (protocol) {
+
+#ifdef IPV6_AVAILABLE
+        case Sn_MR_MACRAW:
+            if ((flag & (SF_DHA_MANUAL | SF_FORCE_ARP)) != 0) {
+                return SOCKERR_SOCKFLAG;
+            }
+            break;
+        case Sn_MR_TCP4:
+        case Sn_MR_TCP6:
+        case Sn_MR_TCPD:
+            if ((flag & (SF_MULTI_ENABLE | SF_UNI_BLOCK)) != 0) {
+                return SOCKERR_SOCKFLAG;
+            }
+            break;
+        case Sn_MR_IPRAW4:
+        case Sn_MR_IPRAW6:
+            if (flag != 0) {
+                return SOCKERR_SOCKFLAG;
+            }
+            break;
+#else
+        case Sn_MR_TCP:
+            //M20150601 :  For SF_TCP_ALIGN & W5300
+#if _WIZCHIP_ == 5300
+            if ((flag & (SF_TCP_NODELAY | SF_IO_NONBLOCK | SF_TCP_ALIGN)) == 0) {
+                return SOCKERR_SOCKFLAG;
+            }
+#else
+            if ((flag & (SF_TCP_NODELAY | SF_IO_NONBLOCK)) == 0) {
+                return SOCKERR_SOCKFLAG;
+            }
+#endif
+
+            break;
+        case Sn_MR_UDP:
+            if (flag & SF_IGMP_VER2) {
+                if ((flag & SF_MULTI_ENABLE) == 0) {
+                    return SOCKERR_SOCKFLAG;
+                }
+            }
+#if _WIZCHIP_ == 5500
+            if (flag & SF_UNI_BLOCK) {
+                if ((flag & SF_MULTI_ENABLE) == 0) {
+                    return SOCKERR_SOCKFLAG;
+                }
+            }
+#endif
+            break;
+
+#endif
+
+        default:
+            break;
+        }
+    }
+    close(sn);
+    //M20150601
+#if _WIZCHIP_ == 5300
+    setSn_MR(sn, ((uint16_t)(protocol | (flag & 0xF0))) | (((uint16_t)(flag & 0x02)) << 7));
+#else
+    setSn_MR(sn, (protocol | (flag & 0xF0)));
+#endif
+#ifdef IPV6_AVAILABLE
+    setSn_MR2(sn, flag & 0x03);
+#endif
+    if (!port) {
+        port = sock_any_port++;
+        if (sock_any_port == 0xFFF0) {
+            sock_any_port = SOCK_ANY_PORT_NUM;
+        }
+    }
+    setSn_PORTR(sn, port);
+    setSn_CR(sn, Sn_CR_OPEN);
+    while (getSn_CR(sn));
+    //A20150401 : For release the previous sock_io_mode
+    sock_io_mode &= ~(1 << sn);
+    //
+#ifndef IPV6_AVAILABLE
+    sock_io_mode |= ((flag & SF_IO_NONBLOCK) << sn);
+#else
+    sock_io_mode |= ((flag & (SF_IO_NONBLOCK >> 3)) << sn);
+#endif
+    sock_is_sending &= ~(1 << sn);
+    sock_remained_size[sn] = 0;
+    //M20150601 : repalce 0 with PACK_COMPLETED
+    //sock_pack_info[sn] = 0;
+    sock_pack_info[sn] = PACK_COMPLETED;//PACK_COMPLETED //TODO::need verify:LINAN 20250421
+    //
+    while (getSn_SR(sn) == SOCK_CLOSED);
+    return (int8_t)sn;
+}
+
+int8_t close(uint8_t sn) {
+    CHECK_SOCKNUM();
+    //A20160426 : Applied the erratum 1 of W5300
+#if   (_WIZCHIP_ == 5300)
+    //M20160503 : Wrong socket parameter. s -> sn
+    //if( ((getSn_MR(s)& 0x0F) == Sn_MR_TCP) && (getSn_TX_FSR(s) != getSn_TxMAX(s)) )
+    if (((getSn_MR(sn) & 0x0F) == Sn_MR_TCP) && (getSn_TX_FSR(sn) != getSn_TxMAX(sn))) {
+        uint8_t destip[4] = {0, 0, 0, 1};
+        // TODO
+        // You can wait for completing to sending data;
+        // wait about 1 second;
+        // if you have completed to send data, skip the code of erratum 1
+        // ex> wait_1s();
+        //     if (getSn_TX_FSR(s) == getSn_TxMAX(s)) continue;
+        //
+        //M20160503 : The socket() of close() calls close() itself again. It occures a infinite loop - close()->socket()->close()->socket()-> ~
+        //socket(s,Sn_MR_UDP,0x3000,0);
+        //sendto(s,destip,1,destip,0x3000); // send the dummy data to an unknown destination(0.0.0.1).
+        setSn_MR(sn, Sn_MR_UDP);
+        setSn_PORTR(sn, 0x3000);
+        setSn_CR(sn, Sn_CR_OPEN);
+        while (getSn_CR(sn) != 0);
+        while (getSn_SR(sn) != SOCK_UDP);
+        sendto(sn, destip, 1, destip, 0x3000); // send the dummy data to an unknown destination(0.0.0.1).
+    };
+#endif
+    setSn_CR(sn, Sn_CR_CLOSE);
+    /* wait to process the command... */
+    while (getSn_CR(sn));
+    /* clear all interrupt of SOCKETn. */
+    setSn_IR(sn, 0xFF);
+    //A20150401 : Release the sock_io_mode of socket n.
+    sock_io_mode &= ~(1 << sn);
+    //
+    sock_is_sending &= ~(1 << sn);
+    sock_remained_size[sn] = 0;
+    sock_pack_info[sn] = PACK_NONE;
+    while (getSn_SR(sn) != SOCK_CLOSED);
+    return SOCK_OK;
+}
+
+int8_t listen(uint8_t sn) {
+    CHECK_SOCKNUM();
+    CHECK_TCPMODE();
+    CHECK_SOCKINIT();
+    setSn_CR(sn, Sn_CR_LISTEN);
+    while (getSn_CR(sn));
+    while (getSn_SR(sn) != SOCK_LISTEN) {
+        close(sn);
+        return SOCKERR_SOCKCLOSED;
+    }
+    return SOCK_OK;
+}
+//int8_t connect (uint8_t sn, uint8_t * addr, uint16_t port )
+int8_t connect_W5x00(uint8_t sn, uint8_t * addr, uint16_t port) {
+    // printf(" W5x00 - connect - addrlen = %d \r\n" , 4 );
+    // #ifdef IPV6_AVAILABLE
+    // TODO :define how to work, when IPV6_AVAILABLE is defined
+    // #endif
+    return connect_IO_6(sn, addr, port, 4);
+}
+
+int8_t connect_W6x00(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen) {
+    // printf(" W6x00 - connect - addrlen = %d \r\n" , addrlen );
+    // #ifdef IPV6_AVAILABLE
+    // TODO :define how to work, when IPV6_AVAILABLE is defined
+    // #endif
+    return connect_IO_6(sn, addr, port, addrlen);
+}
+
+static int8_t connect_IO_6(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen) {
+
+    // printf(" connect - addrlen = %d \r\n" , addrlen );
+
+    CHECK_SOCKNUM();
+    CHECK_TCPMODE(); // same macro " CHECK_SOCKMODE(Sn_MR_TCP);"
+    CHECK_SOCKINIT();
+
+#ifdef IPV6_AVAILABLE
+    CHECK_IPZERO(addr, addrlen);
+#else
+    //M20140501 : For avoiding fatal error on memory align mismatched
+    //if( *((uint32_t*)addr) == 0xFFFFFFFF || *((uint32_t*)addr) == 0) return SOCKERR_IPINVALID;
+    {
+        uint32_t taddr;
+        taddr = ((uint32_t)addr[0] & 0x000000FF);
+        taddr = (taddr << 8) + ((uint32_t)addr[1] & 0x000000FF);
+        taddr = (taddr << 8) + ((uint32_t)addr[2] & 0x000000FF);
+        taddr = (taddr << 8) + ((uint32_t)addr[3] & 0x000000FF);
+        if (taddr == 0xFFFFFFFF || taddr == 0) {
+            return SOCKERR_IPINVALID;
+        }
+    }
+#endif
+
+    if (port == 0) {
+        return SOCKERR_PORTZERO;
+    }
+
+    setSn_DPORTR(sn, port);
+
+    if (addrlen == 16) {   // addrlen=16, Sn_MR_TCP6(1001), Sn_MR_TCPD(1101))
+#ifdef IPV6_AVAILABLE
+        if (getSn_MR(sn) & 0x08) {
+            setSn_DIP6R(sn, addr);
+            setSn_CR(sn, Sn_CR_CONNECT6);
+        } else
+#endif
+            return SOCKERR_SOCKMODE;
+    } else {       // addrlen=4, Sn_MR_TCP4(0001), Sn_MR_TCPD(1101)
+        if (getSn_MR(sn) == Sn_MR_TCP6) {
+            return SOCKERR_SOCKMODE;
+        }
+        setSn_DIPR(sn, addr);
+        //setSn_DPORT(sn,port); //TODO::need verify:LINAN 20250421
+        setSn_CR(sn, Sn_CR_CONNECT);
+    }
+    while (getSn_CR(sn));
+    if (sock_io_mode & (1 << sn)) {
+        return SOCK_BUSY;
+    }
+    while (getSn_SR(sn) != SOCK_ESTABLISHED) {
+        if (getSn_IR(sn) & Sn_IR_TIMEOUT) {
+            setSn_IR(sn, Sn_IR_TIMEOUT);
+            return SOCKERR_TIMEOUT;
+        }
+
+        if (getSn_SR(sn) == SOCK_CLOSED) {
+            return SOCKERR_SOCKCLOSED;
+        }
+    }
+
+    return SOCK_OK;
+}
+
+int8_t disconnect(uint8_t sn) {
+    CHECK_SOCKNUM();
+    CHECK_TCPMODE();
+    if (getSn_SR(sn) != SOCK_CLOSED) {
+        setSn_CR(sn, Sn_CR_DISCON);
+        /* wait to process the command... */
+        while (getSn_CR(sn));
+        sock_is_sending &= ~(1 << sn);
+        if (sock_io_mode & (1 << sn)) {
+            return SOCK_BUSY;
+        }
+        while (getSn_SR(sn) != SOCK_CLOSED) {
+            if (getSn_IR(sn) & Sn_IR_TIMEOUT) {
+                close(sn);
+                return SOCKERR_TIMEOUT;
+            }
+        }
+    }
+    return SOCK_OK;
+}
+
+
+#if 1
+int32_t send(uint8_t sn, uint8_t * buf, uint16_t len) {
+    uint8_t tmp = 0;
+    uint16_t freesize = 0;
+    /*
+        The below codes can be omitted for optmization of speed
+    */
+    //CHECK_SOCKNUM();
+    //CHECK_TCPMODE(Sn_MR_TCP4);
+    /************/
+#ifndef IPV6_AVAILABLE
+    CHECK_SOCKNUM();
+    CHECK_SOCKMODE(Sn_MR_TCP);
+    CHECK_SOCKDATA();
+    tmp = getSn_SR(sn);
+    if (tmp != SOCK_ESTABLISHED && tmp != SOCK_CLOSE_WAIT) {
+        return SOCKERR_SOCKSTATUS;
+    }
+    if (sock_is_sending & (1 << sn)) {
+        tmp = getSn_IR(sn);
+        if (tmp & Sn_IR_SENDOK) {
+            setSn_IR(sn, Sn_IR_SENDOK);
+            //M20150401 : Typing Error
+            //#if _WZICHIP_ == 5200
+#if _WIZCHIP_ == 5200
+            if (getSn_TX_RD(sn) != sock_next_rd[sn]) {
+                setSn_CR(sn, Sn_CR_SEND);
+                while (getSn_CR(sn));
+                return SOCK_BUSY;
+            }
+#endif
+            sock_is_sending &= ~(1 << sn);
+        } else if (tmp & Sn_IR_TIMEOUT) {
+            close(sn);
+            return SOCKERR_TIMEOUT;
+        } else {
+            return SOCK_BUSY;
+        }
+    }
+#endif
+    freesize = getSn_TxMAX(sn);
+    if (len > freesize) {
+        len = freesize;    // check size not to exceed MAX size.
+    }
+    while (1) {
+        freesize = (uint16_t)getSn_TX_FSR(sn);
+        tmp = getSn_SR(sn);
+        if ((tmp != SOCK_ESTABLISHED) && (tmp != SOCK_CLOSE_WAIT)) {
+            if (tmp == SOCK_CLOSED) {
+                close(sn);
+            }
+            return SOCKERR_SOCKSTATUS;
+        }
+        if ((sock_io_mode & (1 << sn)) && (len > freesize)) {
+            return SOCK_BUSY;    //TODO::need verify:LINAN 20250421
+        }
+        // if( sock_io_mode & (1<<sn) ) return SOCK_BUSY;  //TODO::need verify:LINAN 20250421
+        if (len <= freesize) {
+            break;
+        }
+    }
+    wiz_send_data(sn, buf, len);
+#if _WIZCHIP_ == 5200
+    sock_next_rd[sn] = getSn_TX_RD(sn) + len;
+#endif
+
+#if _WIZCHIP_ == 5300
+    setSn_TX_WRSR(sn, len);
+#endif
+    if (sock_is_sending & (1 << sn)) {
+        while (!(getSn_IR(sn) & Sn_IR_SENDOK)) {
+            tmp = getSn_SR(sn);
+            if ((tmp != SOCK_ESTABLISHED) && (tmp != SOCK_CLOSE_WAIT)) {
+                if ((tmp == SOCK_CLOSED) || (getSn_IR(sn) & Sn_IR_TIMEOUT)) {
+                    close(sn);
+                }
+                return SOCKERR_SOCKSTATUS;
+            }
+            if (sock_io_mode & (1 << sn)) {
+                return SOCK_BUSY;
+            }
+        }
+        setSn_IR(sn, Sn_IR_SENDOK);
+    }
+    setSn_CR(sn, Sn_CR_SEND);
+
+    while (getSn_CR(sn));  // wait to process the command...
+    sock_is_sending |= (1 << sn);
+
+    return len;
+}
+#else //for speed optimization, by lihan
+int32_t send(uint8_t sn, uint8_t * buf, uint16_t len) {
+    uint8_t tmp = 0;
+    uint16_t freesize = 0;
+
+    // tx_bufferSize / 4
+
+    //if (len > 4096) len = 4096; // check size not to exceed MAX size.//
+    //if (len > 8192) len = 8192; // check size not to exceed MAX siz
+    //if (len > 16384) len = 16384; // check size not to exceed MAX size.
+    //if (len > 32768) len = 32768; // check size not to exceed MAX size.
+#define __FREESIZE__(i)  1024 * i
+#define __FREESIZE__Value 8
+    if (len > __FREESIZE__(__FREESIZE__Value)) {
+        len = __FREESIZE__(__FREESIZE__Value);    // check size not to exceed MAX size.//tse
+    }
+
+    while (1) {
+        freesize = (uint16_t)getSn_TX_FSR(sn);
+        if (len <= freesize) {
+            break;
+        }
+    }
+    wiz_send_data(sn, buf, len);
+    setSn_CR(sn, Sn_CR_SEND);
+
+    while (getSn_CR(sn));  // wait to process the command...
+    sock_is_sending |= (1 << sn);
+
+    return len;
+}
+#endif
+int32_t recv(uint8_t sn, uint8_t * buf, uint16_t len) { //lihan
+    uint8_t  tmp = 0;
+    uint16_t recvsize = 0;
+    /*
+        The below codes can be omitted for optmization of speed
+    */
+    //A20150601 : For integarating with W5300
+#if   _WIZCHIP_ == 5300
+    uint8_t head[2];
+    uint16_t mr;
+#endif
+    //
+    CHECK_SOCKNUM();
+    CHECK_SOCKMODE(Sn_MR_TCP);
+    CHECK_SOCKDATA();
+
+    recvsize = getSn_RxMAX(sn);
+    if (recvsize < len) {
+        len = recvsize;
+    }
+
+    //A20150601 : For Integrating with W5300
+#if _WIZCHIP_ == 5300
+    //sock_pack_info[sn] = PACK_COMPLETED;    // for clear
+    if (sock_remained_size[sn] == 0) {
+#endif
+        //
+        while (1) {
+            recvsize = (uint16_t)getSn_RX_RSR(sn);
+            tmp = getSn_SR(sn);
+            if (tmp != SOCK_ESTABLISHED) {
+                if (tmp == SOCK_CLOSE_WAIT) {
+                    if (recvsize != 0) {
+                        break;
+                    } else if (getSn_TX_FSR(sn) == getSn_TxMAX(sn)) {
+                        close(sn);
+                        return SOCKERR_SOCKSTATUS;
+                    }
+                } else {
+                    close(sn);
+                    return SOCKERR_SOCKSTATUS;
+                }
+            }
+#ifdef IPV6_AVAILABLE
+            if (recvsize != 0) {
+                break;
+            }
+            if (sock_io_mode & (1 << sn)) {
+                return SOCK_BUSY;
+            }
+#else
+            if (sock_io_mode & (1 << sn)) {
+                return SOCK_BUSY;
+            }
+            if (recvsize != 0) {
+                break;
+            }
+#endif
+        };
+#if _WIZCHIP_ == 5300
+    }
+#endif
+
+    //A20150601 : For integrating with W5300
+#if _WIZCHIP_ == 5300
+    if ((sock_remained_size[sn] == 0) || (getSn_MR(sn) & Sn_MR_ALIGN)) {
+        mr = getMR();
+        if ((getSn_MR(sn) & Sn_MR_ALIGN) == 0) {
+            wiz_recv_data(sn, head, 2);
+            if (mr & MR_FS) {
+                recvsize = (((uint16_t)head[1]) << 8) | ((uint16_t)head[0]);
+            } else {
+                recvsize = (((uint16_t)head[0]) << 8) | ((uint16_t)head[1]);
+            }
+            sock_pack_info[sn] = PACK_FIRST;
+        }
+        sock_remained_size[sn] = recvsize;
+    }
+    if (len > sock_remained_size[sn]) {
+        len = sock_remained_size[sn];
+    }
+    recvsize = len;
+    if (sock_pack_info[sn] & PACK_FIFOBYTE) {
+        *buf = sock_remained_byte[sn];
+        buf++;
+        sock_pack_info[sn] &= ~(PACK_FIFOBYTE);
+        recvsize -= 1;
+        sock_remained_size[sn] -= 1;
+    }
+    if (recvsize != 0) {
+        wiz_recv_data(sn, buf, recvsize);
+        setSn_CR(sn, Sn_CR_RECV);
+        while (getSn_CR(sn));
+    }
+    sock_remained_size[sn] -= recvsize;
+    if (sock_remained_size[sn] != 0) {
+        sock_pack_info[sn] |= PACK_REMAINED;
+        if (recvsize & 0x1) {
+            sock_pack_info[sn] |= PACK_FIFOBYTE;
+        }
+    } else {
+        sock_pack_info[sn] = PACK_COMPLETED;
+    }
+    if (getSn_MR(sn) & Sn_MR_ALIGN) {
+        sock_remained_size[sn] = 0;
+    }
+    //len = recvsize;
+#else
+    if (recvsize < len) {
+        len = recvsize;
+    }
+    wiz_recv_data(sn, buf, len);
+    setSn_CR(sn, Sn_CR_RECV);
+    while (getSn_CR(sn));
+#endif
+
+    //M20150409 : Explicit Type Casting
+    //return len;
+    return (int32_t)len;
+}
+
+
+int32_t sendto_W5x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port) {
+    //static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port)
+    // printf("sendto_W5x00\r\n" ) ;
+    return sendto_IO_6(sn,   buf,  len,   addr,  port, 4);
+}
+
+int32_t sendto_W6x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen) {
+    // printf("sendto_W6x00\r\n" ) ;
+    //static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port)
+    return sendto_IO_6(sn,  buf,  len,   addr,  port, addrlen);
+}
+
+static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen) {
+    uint8_t tmp = 0;
+    uint8_t tcmd = Sn_CR_SEND;
+    uint16_t freesize = 0;
+    uint32_t taddr;
+
+    /*
+        The below codes can be omitted for optmization of speed
+    */
+    CHECK_SOCKNUM();
+    //CHECK_DGRAMMODE();
+    /************/
+    switch (getSn_MR(sn) & 0x0F) {
+    case Sn_MR_UDP:
+    case Sn_MR_MACRAW:
+    //         break;
+    //   #if ( _WIZCHIP_ < 5200 )
+    case Sn_MR_IPRAW:
+    case Sn_MR_IPRAW6:
+        break;
+    //   #endif
+    default:
+        return SOCKERR_SOCKMODE;
+    }
+    tmp = getSn_MR(sn);
+    if (tmp != Sn_MR_MACRAW) {
+        if (addrlen == 16) {    // addrlen=16, Sn_MR_UDP6(1010), Sn_MR_UDPD(1110)), IPRAW6(1011)
+#ifdef IPV6_AVAILABLE
+            if (tmp & 0x08) {
+                setSn_DIP6R(sn, addr);
+                tcmd = Sn_CR_SEND6;
+            } else
+#endif
+                return SOCKERR_SOCKMODE;
+        } else if (addrlen == 4) { // addrlen=4, Sn_MR_UDP4(0010), Sn_MR_UDPD(1110), IPRAW4(0011)
+            if (tmp == Sn_MR_UDP6 || tmp == Sn_MR_IPRAW6) {
+                return SOCKERR_SOCKMODE;
+            }
+            setSn_DIPR(sn, addr);
+            tcmd = Sn_CR_SEND;
+        } else {
+            return SOCKERR_IPINVALID;
+        }
+    }
+    if ((tmp & 0x03) == 0x02) { // Sn_MR_UPD4(0010), Sn_MR_UDP6(1010), Sn_MR_UDPD(1110)
+        if (port) {
+            setSn_DPORTR(sn, port);
+        } else {
+            return SOCKERR_PORTZERO;
+        }
+    }
+#ifndef IPV6_AVAILABLE
+    CHECK_SOCKDATA();
+    //M20140501 : For avoiding fatal error on memory align mismatched
+    //if(*((uint32_t*)addr) == 0) return SOCKERR_IPINVALID;
+    //{
+    //uint32_t taddr;
+    taddr = ((uint32_t)addr[0]) & 0x000000FF;
+    taddr = (taddr << 8) + ((uint32_t)addr[1] & 0x000000FF);
+    taddr = (taddr << 8) + ((uint32_t)addr[2] & 0x000000FF);
+    taddr = (taddr << 8) + ((uint32_t)addr[3] & 0x000000FF);
+    //}
+    //
+    //if(*((uint32_t*)addr) == 0) return SOCKERR_IPINVALID;
+    if ((taddr == 0) && ((getSn_MR(sn)&Sn_MR_MACRAW) != Sn_MR_MACRAW)) {
+        return SOCKERR_IPINVALID;
+    }
+    if ((port  == 0) && ((getSn_MR(sn)&Sn_MR_MACRAW) != Sn_MR_MACRAW)) {
+        return SOCKERR_PORTZERO;
+    }
+    tmp = getSn_SR(sn);
+    //#if ( _WIZCHIP_ < 5200 )
+    if ((tmp != SOCK_MACRAW) && (tmp != SOCK_UDP) && (tmp != SOCK_IPRAW)) {
+        return SOCKERR_SOCKSTATUS;
+    }
+    //#else
+    //   if(tmp != SOCK_MACRAW && tmp != SOCK_UDP) return SOCKERR_SOCKSTATUS;
+    //#endif
+
+    setSn_DIPR(sn, addr);
+    setSn_DPORT(sn, port);
+#endif
+
+    freesize = getSn_TxMAX(sn);
+    if (len > freesize) {
+        len = freesize;    // check size not to exceed MAX size.
+    }
+
+    while (1) {
+        freesize = getSn_TX_FSR(sn);
+        if (getSn_SR(sn) == SOCK_CLOSED) {
+            return SOCKERR_SOCKCLOSED;
+        }
+        if ((sock_io_mode & (1 << sn)) && (len > freesize)) {
+            return SOCK_BUSY;
+        }
+        if (len <= freesize) {
+            break;
+        }
+    };
+    wiz_send_data(sn, buf, len);
+
+#if _WIZCHIP_ < 5500   //M20150401 : for WIZCHIP Errata #4, #5 (ARP errata)
+    getSIPR((uint8_t *)&taddr);
+    if (taddr == 0) {
+        getSUBR((uint8_t*)&taddr);
+        setSUBR((uint8_t*)"\x00\x00\x00\x00");
+    } else {
+        taddr = 0;
+    }
+#endif
+
+#ifdef IPV6_AVAILABLE
+    setSn_CR(sn, tcmd);
+#else
+    //A20150601 : For W5300
+#if _WIZCHIP_ == 5300
+    setSn_TX_WRSR(sn, len);
+#endif
+    //
+    setSn_CR(sn, Sn_CR_SEND);
+#endif
+    /* wait to process the command... */
+    while (getSn_CR(sn));
+    while (1) {
+        tmp = getSn_IR(sn);
+        if (tmp & Sn_IR_SENDOK) {
+            setSn_IR(sn, Sn_IR_SENDOK);
+            break;
+        }
+        //M:20131104
+        //else if(tmp & Sn_IR_TIMEOUT) return SOCKERR_TIMEOUT;
+        else if (tmp & Sn_IR_TIMEOUT) {
+            setSn_IR(sn, Sn_IR_TIMEOUT);
+            //M20150409 : Fixed the lost of sign bits by type casting.
+            //len = (uint16_t)SOCKERR_TIMEOUT;
+            //break;
+#if _WIZCHIP_ < 5500   //M20150401 : for WIZCHIP Errata #4, #5 (ARP errata)
+            if (taddr) {
+                setSUBR((uint8_t*)&taddr);
+            }
+#endif
+            return SOCKERR_TIMEOUT;
+        }
+        ////////////
+    }
+#if _WIZCHIP_ < 5500   //M20150401 : for WIZCHIP Errata #4, #5 (ARP errata)
+    if (taddr) {
+        setSUBR((uint8_t*)&taddr);
+    }
+#endif
+    //M20150409 : Explicit Type Casting
+    //return len;
+    return (int32_t)len;
+}
+
+
+
+int32_t recvfrom_W5x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port) {
+    //int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port)
+    // printf("recvfrom_W5x00\r\n" ) ;
+    uint8_t addrlen = 4; //M20150601 : For W5300
+    uint8_t *dummy = &addrlen;
+    return recvfrom_IO_6(sn,   buf,  len,   addr,  port, dummy);
+}
+
+int32_t recvfrom_W6x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen) {
+    // printf("recvfrom_W6x00\r\n" ) ;
+    //int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port)
+    return recvfrom_IO_6(sn,  buf,  len,   addr,  port, addrlen);
+}
+static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen) { //TODO : WILL BE IMPROVED
+    //M20150601 : For W5300
+#if _WIZCHIP_ == 5300
+    uint16_t mr;
+    uint16_t mr1;
+#else
+    uint8_t  mr;
+#endif
+    //
+    uint8_t  head[8];
+    uint16_t pack_len = 0;
+
+    /*
+        The below codes can be omitted for optmization of speed
+    */
+    CHECK_SOCKNUM();
+    //CHECK_DGRAMMODE();
+    //CHECK_SOCKDATA();
+    /************/
+    //CHECK_SOCKMODE(Sn_MR_UDP);
+    //A20150601
+#if _WIZCHIP_ == 5300
+    mr1 = getMR();
+#endif
+
+    switch ((mr = getSn_MR(sn)) & 0x0F) {
+    case Sn_MR_UDP:
+    case Sn_MR_IPRAW:
+    case Sn_MR_IPRAW6:
+    case Sn_MR_MACRAW:
+        break;
+#if ( _WIZCHIP_ < 5200 )
+    case Sn_MR_PPPoE:
+        break;
+#endif
+    default:
+        return SOCKERR_SOCKMODE;
+    }
+    CHECK_SOCKDATA();
+    if (sock_remained_size[sn] == 0) {
+        while (1) {
+            pack_len = getSn_RX_RSR(sn);
+            if (getSn_SR(sn) == SOCK_CLOSED) {
+                return SOCKERR_SOCKCLOSED;
+            }
+#ifndef IPV6_AVAILABLE
+            if ((sock_io_mode & (1 << sn)) && (pack_len == 0)) {
+                return SOCK_BUSY;
+            }
+            if (pack_len != 0) {
+                break;
+            }
+#else
+            if (pack_len != 0) {
+                sock_pack_info[sn] = PACK_NONE;
+                break;
+            }
+            if (sock_io_mode & (1 << sn)) {
+                return SOCK_BUSY;
+            }
+#endif
+        };
+    }
+#ifdef IPV6_AVAILABLE
+    /* First read 2 bytes of PACKET INFO in SOCKETn RX buffer*/
+    wiz_recv_data(sn, head, 2);
+    setSn_CR(sn, Sn_CR_RECV);
+    while (getSn_CR(sn));
+    pack_len = head[0] & 0x07;
+    pack_len = (pack_len << 8) + head[1];
+#endif
+    //D20150601 : Move it to bottom
+    // sock_pack_info[sn] = PACK_COMPLETED;
+    switch (mr & 0x07) {
+    case Sn_MR_UDP4 :
+    case Sn_MR_UDP6:
+    case Sn_MR_UDPD:
+#ifdef IPV6_AVAILABLE
+        if (addr == 0) {
+            return SOCKERR_ARG;
+        }
+
+        sock_pack_info[sn] = head[0] & 0xF8;
+
+        if (sock_pack_info[sn] & PACK_IPv6) {
+            *addrlen = 16 ;
+        } else {
+            *addrlen = 4 ;
+        }
+        wiz_recv_data(sn, addr, *addrlen);
+        setSn_CR(sn, Sn_CR_RECV);
+
+        while (getSn_CR(sn));
+
+#else
+        if (sock_remained_size[sn] == 0) {
+            wiz_recv_data(sn, head, 8);
+            setSn_CR(sn, Sn_CR_RECV);
+            while (getSn_CR(sn));
+            // read peer's IP address, port number & packet length
+            //A20150601 : For W5300
+#if _WIZCHIP_ == 5300
+            if (mr1 & MR_FS) {
+                addr[0] = head[1];
+                addr[1] = head[0];
+                addr[2] = head[3];
+                addr[3] = head[2];
+                *port = head[5];
+                *port = (*port << 8) + head[4];
+                sock_remained_size[sn] = head[7];
+                sock_remained_size[sn] = (sock_remained_size[sn] << 8) + head[6];
+            } else {
+#endif
+                addr[0] = head[0];
+                addr[1] = head[1];
+                addr[2] = head[2];
+                addr[3] = head[3];
+                *port = head[4];
+                *port = (*port << 8) + head[5];
+                sock_remained_size[sn] = head[6];
+                sock_remained_size[sn] = (sock_remained_size[sn] << 8) + head[7];
+#if _WIZCHIP_ == 5300
+            }
+#endif
+            sock_pack_info[sn] = PACK_FIRST;
+        }
+        if (len < sock_remained_size[sn]) {
+            pack_len = len;
+        } else {
+            pack_len = sock_remained_size[sn];
+        }
+        //A20150601 : For W5300
+        len = pack_len;
+#if _WIZCHIP_ == 5300
+        if (sock_pack_info[sn] & PACK_FIFOBYTE) {
+            *buf++ = sock_remained_byte[sn];
+            pack_len -= 1;
+            sock_remained_size[sn] -= 1;
+            sock_pack_info[sn] &= ~PACK_FIFOBYTE;
+        }
+#endif
+        //
+        // Need to packet length check (default 1472)
+        //
+        wiz_recv_data(sn, buf, pack_len); // data copy.
+#endif
+        break;
+    case Sn_MR_MACRAW :
+        if (sock_remained_size[sn] == 0) {
+#ifndef IPV6_AVAILABLE
+            wiz_recv_data(sn, head, 2);
+            setSn_CR(sn, Sn_CR_RECV);
+            while (getSn_CR(sn));
+#endif
+            // read peer's IP address, port number & packet length
+            sock_remained_size[sn] = head[0];
+            sock_remained_size[sn] = (sock_remained_size[sn] << 8) + head[1] - 2;
+#if _WIZCHIP_ == W5300
+            if (sock_remained_size[sn] & 0x01) {
+                sock_remained_size[sn] = sock_remained_size[sn] + 1 - 4;
+            } else {
+                sock_remained_size[sn] -= 4;
+            }
+#endif
+            if (sock_remained_size[sn] > 1514) {
+                close(sn);
+                return SOCKFATAL_PACKLEN;
+            }
+            sock_pack_info[sn] = PACK_FIRST;
+        }
+        if (len < sock_remained_size[sn]) {
+            pack_len = len;
+        } else {
+            pack_len = sock_remained_size[sn];
+        }
+        wiz_recv_data(sn, buf, pack_len);
+        break;
+    //#if ( _WIZCHIP_ < 5200 )
+    case Sn_MR_IPRAW6:
+    case Sn_MR_IPRAW4 :
+        if (sock_remained_size[sn] == 0) {
+#ifndef IPV6_AVAILABLE
+            wiz_recv_data(sn, head, 6);
+            setSn_CR(sn, Sn_CR_RECV);
+            while (getSn_CR(sn));
+            addr[0] = head[0];
+            addr[1] = head[1];
+            addr[2] = head[2];
+            addr[3] = head[3];
+            sock_remained_size[sn] = head[4];
+            //M20150401 : For Typing Error
+            //sock_remaiend_size[sn] = (sock_remained_size[sn] << 8) + head[5];
+            sock_remained_size[sn] = (sock_remained_size[sn] << 8) + head[5];
+            sock_pack_info[sn] = PACK_FIRST;
+            //
+            // Need to packet length check
+            //
+            if (len < sock_remained_size[sn]) {
+                pack_len = len;
+            } else {
+                pack_len = sock_remained_size[sn];
+            }
+            wiz_recv_data(sn, buf, pack_len); // data copy.
+#else
+            if (*addr == 0) {
+                return SOCKERR_ARG;
+            }
+            sock_pack_info[sn] = head[0] & 0xF8;
+            if (sock_pack_info[sn] & PACK_IPv6) {
+                *addrlen = 16;
+            } else {
+                *addrlen = 4;
+            }
+            wiz_recv_data(sn, addr, *addrlen);
+            setSn_CR(sn, Sn_CR_RECV);
+            while (getSn_CR(sn));
+
+#endif
+        }
+        break;
+    default:
+        wiz_recv_ignore(sn, pack_len); // data copy.
+        sock_remained_size[sn] = pack_len;
+        break;
+    }
+#ifdef IPV6_AVAILABLE
+    sock_remained_size[sn] = pack_len;
+    sock_pack_info[sn] |= PACK_FIRST;
+    if ((getSn_MR(sn) & 0x03) == 0x02) { // Sn_MR_UDP4(0010), Sn_MR_UDP6(1010), Sn_MR_UDPD(1110)
+        /* Read port number of PACKET INFO in SOCKETn RX buffer */
+        if (port == 0) {
+            return SOCKERR_ARG;
+        }
+        wiz_recv_data(sn, head, 2);
+        *port = (((((uint16_t)head[0])) << 8) + head[1]);
+        setSn_CR(sn, Sn_CR_RECV);
+        while (getSn_CR(sn));
+    }
+
+    if (len < sock_remained_size[sn]) {
+        pack_len = len;
+    } else {
+        pack_len = sock_remained_size[sn];
+    }
+    wiz_recv_data(sn, buf, pack_len);
+    setSn_CR(sn, Sn_CR_RECV);
+    /* wait to process the command... */
+    while (getSn_CR(sn)) ;
+
+    sock_remained_size[sn] -= pack_len;
+    if (sock_remained_size[sn] != 0) {
+        sock_pack_info[sn] |= PACK_REMAINED;
+    } else {
+        sock_pack_info[sn] |= PACK_COMPLETED;
+    }
+
+#else
+    setSn_CR(sn, Sn_CR_RECV);
+    /* wait to process the command... */
+    while (getSn_CR(sn)) ;
+    sock_remained_size[sn] -= pack_len;
+    //M20150601 :
+    //if(sock_remained_size[sn] != 0) sock_pack_info[sn] |= 0x01;
+    if (sock_remained_size[sn] != 0) {
+        sock_pack_info[sn] |= PACK_REMAINED;
+#if _WIZCHIP_ == 5300
+        if (pack_len & 0x01) {
+            sock_pack_info[sn] |= PACK_FIFOBYTE;
+        }
+#endif
+    } else {
+        sock_pack_info[sn] = PACK_COMPLETED;
+    }
+#if _WIZCHIP_ == 5300
+    pack_len = len;
+#endif
+    //
+    //M20150409 : Explicit Type Casting
+    //return pack_len;
+#endif
+    return (int32_t)pack_len;
+}
+
+
+int8_t  ctlsocket(uint8_t sn, ctlsock_type cstype, void* arg) {
+    uint8_t tmp = 0;
+    CHECK_SOCKNUM();
+    tmp = *((uint8_t*)arg);
+    switch (cstype) {
+    case CS_SET_IOMODE:
+        if (tmp == SOCK_IO_NONBLOCK) {
+            sock_io_mode |= (1 << sn);
+        } else if (tmp == SOCK_IO_BLOCK) {
+            sock_io_mode &= ~(1 << sn);
+        } else {
+            return SOCKERR_ARG;
+        }
+        break;
+    case CS_GET_IOMODE:
+        //M20140501 : implict type casting -> explict type casting
+        //*((uint8_t*)arg) = (sock_io_mode >> sn) & 0x0001;
+        *((uint8_t*)arg) = (uint8_t)((sock_io_mode >> sn) & 0x0001);
+        //
+        break;
+    case CS_GET_MAXTXBUF:
+        *((uint16_t*)arg) = getSn_TxMAX(sn);
+        break;
+    case CS_GET_MAXRXBUF:
+        *((uint16_t*)arg) = getSn_RxMAX(sn);
+        break;
+    case CS_CLR_INTERRUPT:
+        if (tmp > SIK_ALL) {
+            return SOCKERR_ARG;
+        }
+        setSn_IR(sn, tmp);
+        break;
+    case CS_GET_INTERRUPT:
+        *((uint8_t*)arg) = getSn_IR(sn);
+        break;
+#if _WIZCHIP_ != 5100
+    case CS_SET_INTMASK:
+        if (tmp > SIK_ALL) {
+            return SOCKERR_ARG;
+        }
+        setSn_IMR(sn, tmp);
+        break;
+    case CS_GET_INTMASK:
+        *((uint8_t*)arg) = getSn_IMR(sn);
+        break;
+#endif
+#ifdef IPV6_AVAILABLE
+    case CS_SET_PREFER:
+        if ((tmp & 0x03) == 0x01) {
+            return SOCKERR_ARG;
+        }
+        setSn_PSR(sn, tmp);
+        break;
+    case CS_GET_PREFER:
+        *(uint8_t*) arg = getSn_PSR(sn);
+        break;
+#endif
+    default:
+        return SOCKERR_ARG;
+    }
+    return SOCK_OK;
+}
+
+int8_t  setsockopt(uint8_t sn, sockopt_type sotype, void* arg) {
+    // M20131220 : Remove warning
+    //uint8_t tmp;
+    CHECK_SOCKNUM();
+    switch (sotype) {
+    case SO_TTL:
+        setSn_TTL(sn, *(uint8_t*)arg);
+        break;
+    case SO_TOS:
+        setSn_TOS(sn, *(uint8_t*)arg);
+        break;
+    case SO_MSS:
+        setSn_MSSR(sn, *(uint16_t*)arg);
+        break;
+    case SO_DESTIP:
+#ifdef IPV6_AVAILABLE
+        if (((wiz_IPAddress *)arg)->len == 16) {
+            setSn_DIP6R(sn, ((wiz_IPAddress*)arg)->ip);
+        } else
+#endif
+            setSn_DIPR(sn, (uint8_t*)arg);
+        break;
+    case SO_DESTPORT:
+        setSn_DPORTR(sn, *(uint16_t*)arg);
+        break;
+#if _WIZCHIP_ != 5100
+    case SO_KEEPALIVESEND:
+        CHECK_TCPMODE();
+#if _WIZCHIP_ > 5200
+        if (getSn_KPALVTR(sn) != 0) {
+            return SOCKERR_SOCKOPT;
+        }
+#endif
+        setSn_CR(sn, Sn_CR_SEND_KEEP);
+        while (getSn_CR(sn) != 0) {
+            // M20131220
+            //if ((tmp = getSn_IR(sn)) & Sn_IR_TIMEOUT)
+            if (getSn_IR(sn) & Sn_IR_TIMEOUT) {
+                setSn_IR(sn, Sn_IR_TIMEOUT);
+                return SOCKERR_TIMEOUT;
+            }
+        }
+        break;
+#if _WIZCHIP_ > 5200
+    case SO_KEEPALIVEAUTO:
+        CHECK_TCPMODE();
+        setSn_KPALVTR(sn, *(uint8_t*)arg);
+        break;
+#endif
+#endif
+    default:
+        return SOCKERR_ARG;
+    }
+    return SOCK_OK;
+}
+
+int8_t getsockopt(uint8_t sn, sockopt_type sotype, void* arg) {
+    CHECK_SOCKNUM();
+    switch (sotype) {
+    case SO_FLAG:
+#ifdef IPV6_AVAILABLE
+        *(uint8_t*)arg = (getSn_MR(sn) & 0xF0) | (getSn_MR2(sn)) | ((uint8_t)(((sock_io_mode >> sn) & 0x0001) << 3));
+#endif
+        *(uint8_t*)arg = getSn_MR(sn) & 0xF0;
+        break;
+    case SO_TTL:
+        *(uint8_t*) arg = getSn_TTL(sn);
+        break;
+    case SO_TOS:
+        *(uint8_t*) arg = getSn_TOS(sn);
+        break;
+    case SO_MSS:
+        *(uint16_t*) arg = getSn_MSSR(sn);
+        break;
+    case SO_DESTIP:
+#ifdef IPV6_AVAILABLE
+        CHECK_TCPMODE();
+        if (getSn_ESR(sn) & TCPSOCK_MODE) { //IPv6 ?
+            getSn_DIP6R(sn, ((wiz_IPAddress*)arg)->ip);
+            ((wiz_IPAddress*)arg)->len = 16;
+        } else {
+            getSn_DIPR(sn, ((wiz_IPAddress*)arg)->ip);
+            ((wiz_IPAddress*)arg)->len = 4;
+        }
+        break;
+#else
+        getSn_DIPR(sn, (uint8_t*)arg);
+        break;
+#endif
+    case SO_DESTPORT:
+        *(uint16_t*) arg = getSn_DPORTR(sn);
+        break;
+#if  _WIZCHIP_ > 5200
+    case SO_KEEPALIVEAUTO:
+        CHECK_TCPMODE();
+        *(uint16_t*) arg = getSn_KPALVTR(sn);
+        break;
+#endif
+    case SO_SENDBUF:
+        *(uint16_t*) arg = getSn_TX_FSR(sn);
+        break;
+    case SO_RECVBUF:
+        *(uint16_t*) arg = getSn_RX_RSR(sn);
+        break;
+    case SO_STATUS:
+        *(uint8_t*) arg = getSn_SR(sn);
+        break;
+#ifdef IPV6_AVAILABLE
+    case SO_EXTSTATUS:
+        CHECK_TCPMODE();
+        *(uint8_t*) arg = getSn_ESR(sn) & 0x07;
+        break;
+    case SO_REMAINSIZE:
+        if (getSn_MR(sn) == SOCK_CLOSED) {
+            return SOCKERR_SOCKSTATUS;
+        }
+        if (getSn_MR(sn) & 0x01) {
+            *(uint16_t*)arg = getSn_RX_RSR(sn);
+        } else {
+            *(uint16_t*)arg = sock_remained_size[sn];
+        }
+        break;
+    case SO_PACKINFO:
+        if (getSn_MR(sn) == SOCK_CLOSED) {
+            return SOCKERR_SOCKSTATUS;
+        }
+        if (getSn_MR(sn) & 0x01) {
+            return SOCKERR_SOCKMODE;
+        } else {
+            *(uint8_t*)arg = sock_pack_info[sn];
+        }
+        break;
+    case SO_MODE:
+        *(uint8_t*) arg = 0x0F & getSn_MR(sn);
+        break;
+#else
+    case SO_REMAINSIZE:
+        if (getSn_MR(sn) & Sn_MR_TCP) {
+            *(uint16_t*)arg = getSn_RX_RSR(sn);
+        } else {
+            *(uint16_t*)arg = sock_remained_size[sn];
+        }
+        break;
+    case SO_PACKINFO  :
+        //CHECK_SOCKMODE(Sn_MR_TCP);
+#if _WIZCHIP_ != 5300
+        if ((getSn_MR(sn) == Sn_MR_TCP)) {
+            return SOCKERR_SOCKMODE;
+        }
+#endif
+        *(uint8_t*)arg = sock_pack_info[sn];
+        break;
+
+#endif
+    default:
+        return SOCKERR_SOCKOPT;
+    }
+    return SOCK_OK;
+}
+
+#ifdef IPV6_AVAILABLE
+int16_t peeksockmsg(uint8_t sn, uint8_t* submsg, uint16_t subsize) {
+    uint32_t rx_ptr = 0;
+    uint16_t i = 0, sub_idx = 0;
+
+    if ((getSn_RX_RSR(sn) > 0) && (subsize > 0)) {
+        rx_ptr = ((uint32_t)getSn_RX_RD(sn) << 8)  + WIZCHIP_RXBUF_BLOCK(sn);
+        sub_idx = 0;
+        for (i = 0; i < getSn_RX_RSR(sn) ; i++) {
+            if (WIZCHIP_READ(rx_ptr) == submsg[sub_idx]) {
+                sub_idx++;
+                if (sub_idx == subsize) {
+                    return (i + 1 - sub_idx);
+                }
+            } else {
+                sub_idx = 0;
+            }
+            rx_ptr = WIZCHIP_OFFSET_INC(rx_ptr, 1);
+        }
+    }
+    return -1;
+}
+
+
+#endif
+

--- a/third_party/ioLibrary_Driver/Ethernet/socket.h
+++ b/third_party/ioLibrary_Driver/Ethernet/socket.h
@@ -1,0 +1,736 @@
+//*****************************************************************************
+//
+//! \file socket.h
+//! \brief SOCKET APIs Header file.
+//! \details SOCKET APIs like as berkeley socket api.
+//! \version 1.0.2
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2014/05/01> V1.0.2. Refer to M20140501
+//!         1. Modify the comment : SO_REMAINED -> PACK_REMAINED
+//!         2. Add the comment as zero byte udp data reception in getsockopt().
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+/**
+    @defgroup WIZnet_socket_APIs 1. WIZnet socket APIs
+    @brief WIZnet socket APIs are based on Berkeley socket APIs,  thus it has much similar name and interface.
+          But there is a little bit of difference.
+    @details
+    <b> Comparison between WIZnet and Berkeley SOCKET APIs </b>
+    <table>
+      <tr>   <td><b>API</b></td> <td><b>WIZnet</b></td> <td><b>Berkeley</b></td>   </tr>
+      <tr>   <td>socket()</td> <td>O</td> <td>O</td>   </tr>
+      <tr>   <td><b>bind()</b></td> <td>X</td> <td>O</td>   </tr>
+      <tr>   <td><b>listen()</b></td> <td>O</td> <td>O</td>   </tr>
+      <tr>   <td><b>connect()</b></td> <td>O</td> <td>O</td>   </tr>
+      <tr>   <td><b>accept()</b></td> <td>X</td> <td>O</td>   </tr>
+      <tr>   <td><b>recv()</b></td> <td>O</td> <td>O</td>    </tr>
+      <tr>   <td><b>send()</b></td> <td>O</td> <td>O</td>   </tr>
+      <tr>   <td><b>recvfrom()</b></td> <td>O</td> <td>O</td>   </tr>
+      <tr>   <td><b>sendto()</b></td> <td>O</td> <td>O</td>    </tr>
+      <tr>   <td><b>closesocket()</b></td> <td>O<br>close() & disconnect()</td> <td>O</td>   </tr>
+    </table>
+    There are @b bind() and @b accept() functions in @b Berkeley SOCKET API but,
+    not in @b WIZnet SOCKET API. Because socket() of WIZnet is not only creating a SOCKET but also binding a local port number,
+    and listen() of WIZnet is not only listening to connection request from client but also accepting the connection request. \n
+    When you program "TCP SERVER" with Berkeley SOCKET API, you can use only one listen port.
+    When the listen SOCKET accepts a connection request from a client, it keeps listening.
+    After accepting the connection request, a new SOCKET is created and the new SOCKET is used in communication with the client. \n
+    Following figure shows network flow diagram by Berkeley SOCKET API.
+    @image html Berkeley_SOCKET.jpg "<Berkeley SOCKET API>"
+    But, When you program "TCP SERVER" with WIZnet SOCKET API, you can use as many as 8 listen SOCKET with same port number. \n
+    Because there's no accept() in WIZnet SOCKET APIs, when the listen SOCKET accepts a connection request from a client,
+    it is changed in order to communicate with the client.
+    And the changed SOCKET is not listening any more and is dedicated for communicating with the client. \n
+    If there're many listen SOCKET with same listen port number and a client requests a connection,
+    the SOCKET which has the smallest SOCKET number accepts the request and is changed as communication SOCKET. \n
+    Following figure shows network flow diagram by WIZnet SOCKET API.
+    @image html WIZnet_SOCKET.jpg "<WIZnet SOCKET API>"
+*/
+#ifndef _SOCKET_H_
+#define _SOCKET_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "wizchip_conf.h"
+
+#define SOCKET                uint8_t  ///< SOCKET type define for legacy driver
+
+#define SOCK_OK               1        ///< Result is OK about socket process.
+#define SOCK_BUSY             0        ///< Socket is busy on processing the operation. Valid only Non-block IO Mode.
+#define SOCK_FATAL            -1000    ///< Result is fatal error about socket process.
+
+#define SOCK_ERROR            0
+#define SOCKERR_SOCKNUM       (SOCK_ERROR - 1)     ///< Invalid socket number
+#define SOCKERR_SOCKOPT       (SOCK_ERROR - 2)     ///< Invalid socket option
+#define SOCKERR_SOCKINIT      (SOCK_ERROR - 3)     ///< Socket is not initialized or SIPR is Zero IP address when Sn_MR_TCP
+#define SOCKERR_SOCKCLOSED    (SOCK_ERROR - 4)     ///< Socket unexpectedly closed.
+#define SOCKERR_SOCKMODE      (SOCK_ERROR - 5)     ///< Invalid socket mode for socket operation.
+#define SOCKERR_SOCKFLAG      (SOCK_ERROR - 6)     ///< Invalid socket flag
+#define SOCKERR_SOCKSTATUS    (SOCK_ERROR - 7)     ///< Invalid socket status for socket operation.
+#define SOCKERR_ARG           (SOCK_ERROR - 10)    ///< Invalid argument.
+#define SOCKERR_PORTZERO      (SOCK_ERROR - 11)    ///< Port number is zero
+#define SOCKERR_IPINVALID     (SOCK_ERROR - 12)    ///< Invalid IP address
+#define SOCKERR_TIMEOUT       (SOCK_ERROR - 13)    ///< Timeout occurred
+#define SOCKERR_DATALEN       (SOCK_ERROR - 14)    ///< Data length is zero or greater than buffer max size.
+#define SOCKERR_BUFFER        (SOCK_ERROR - 15)    ///< Socket buffer is not enough for data communication.
+
+#define SOCKFATAL_PACKLEN     (SOCK_FATAL - 1)     ///< Invalid packet length. Fatal Error.
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+/*
+    SOCKET FLAG
+*/
+#define SF_ETHER_OWN           (Sn_MR_MFEN)        ///< In @ref Sn_MR_MACRAW, Receive only the packet as broadcast, multicast and own packet
+#define SF_IGMP_VER2           (Sn_MR_MC)          ///< In @ref Sn_MR_UDP with \ref SF_MULTI_ENABLE, Select IGMP version 2.   
+#define SF_TCP_NODELAY         (Sn_MR_ND)          ///< In @ref Sn_MR_TCP, Use to nodelayed ack.
+#define SF_MULTI_ENABLE        (Sn_MR_MULTI)       ///< In @ref Sn_MR_UDP, Enable multicast mode.
+
+#define Sn_MR2_DHAM          (1<<1)
+#define SF_DHA_MANUAL        (Sn_MR2_DHAM)
+#define Sn_MR2_FARP          (1<<0)
+#define SF_FORCE_ARP         (Sn_MR2_FARP)
+
+
+#if _WIZCHIP_ == 5500
+#define SF_BROAD_BLOCK         (Sn_MR_BCASTB)   ///< In @ref Sn_MR_UDP or @ref Sn_MR_MACRAW, Block broadcast packet. Valid only in W5500
+#define SF_MULTI_BLOCK         (Sn_MR_MMB)      ///< In @ref Sn_MR_MACRAW, Block multicast packet. Valid only in W5500
+#define SF_IPv6_BLOCK          (Sn_MR_MIP6B)    ///< In @ref Sn_MR_MACRAW, Block IPv6 packet. Valid only in W5500
+#define SF_UNI_BLOCK           (Sn_MR_UCASTB)   ///< In @ref Sn_MR_UDP with \ref SF_MULTI_ENABLE. Valid only in W5500
+#endif
+
+//A201505 : For W5300
+#if _WIZCHIP_ == 5300
+#define SF_TCP_ALIGN		     0x02			   ///< Valid only \ref Sn_MR_TCP and W5300, refer to \ref Sn_MR_ALIGN
+#endif
+
+#define SF_IO_NONBLOCK           0x01              ///< Socket nonblock io mode. It used parameter in \ref socket().
+
+/*
+    UDP & MACRAW Packet Infomation
+*/
+#define PACK_FIRST               0x80              ///< In Non-TCP packet, It indicates to start receiving a packet. (When W5300, This flag can be applied)
+#define PACK_REMAINED            0x01              ///< In Non-TCP packet, It indicates to remain a packet to be received. (When W5300, This flag can be applied)
+#define PACK_COMPLETED           0x00              ///< In Non-TCP packet, It indicates to complete to receive a packet. (When W5300, This flag can be applied)
+//A20150601 : For Integrating with W5300
+#define PACK_FIFOBYTE            0x02              ///< Valid only W5300, It indicate to have read already the Sn_RX_FIFOR.
+//
+//teddy 240122
+
+#define PACK_IPv6            (1<<7)                ///< It indicates the destination IP address of the received packet is IPv6 or IPv4.
+#define PACK_IPV6_ALLNODE    (PACK_IPv6 | (1<<6))  ///< It indicates the destination IP address of the received packet is allnode multicast(broadcast) address or not.
+#define PACK_IPV6_MULTI      (PACK_IPv6 | (1<<5))  ///< It indicates the destination IP address of the received packet is multicast address or not.
+#define PACK_IPV6_LLA        (PACK_IPv6 | (1<<4))  ///< It indicates the destination IP address of the received packet is lla or gua.
+#define PACK_NONE            (0x00)                ///< It indicates no information of a packet
+
+#elif ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+
+/*
+    - @ref Sn_MR_MULTI : Support UDP Multicasting
+    - @ref Sn_MR_MF    : Support MAC Filter Enable
+    - @ref Sn_MR_BRDB  : Broadcast Block
+    - @ref Sn_MR_FPSH  : Force PSH flag
+    - @ref Sn_MR_ND    : No Delay ACK flag
+    - @ref Sn_MR_MC    : IGMP ver2, ver1
+    - @ref Sn_MR_SMB   : Solicited Multicast Block
+    - @ref Sn_MR_MMB   : IPv4 Multicast block
+    - @ref Sn_MR_UNIB  : Unicast Block
+    - @ref Sn_MR_MMB6  : IPv6 UDP Multicast Block </b>
+
+    - @ref Sn_MR2_DHAM : @ref Sn_MR2_DHAM_AUTO, @ref Sn_MR2_DHAM_MANUAL
+    - @ref Sn_MR_FARP
+*/
+
+/*
+    SOCKET FLAG
+*/
+/**
+    @brief In UDP mode such as @ref Sn_MR_UDP4 and @ref Sn_MR_UDP6, @ref Sn_MR_UDP6, Enable multicast mode. When @ref Sn_MR_UDP6, Enable only IPv6 Multicating.
+*/
+#define SF_MULTI_ENABLE      (Sn_MR_MULTI)
+#define SF_ETHER_OWN         (Sn_MR_MF)       ///< In MACRAW mode such as @ref Sn_MR_MACRAW, Receive only the packet as broadcast, multicast and own packet
+
+/**
+    @brief In UDP mode such as @ref Sn_MR_UDP4, @ref Sn_MR_UDP6 and @ref Sn_MR_UDPD, or In MACRAW mode sucha as @ref Sn_MR_MACRAW, Block a broadcast packet.
+*/
+#define SF_BROAD_BLOCK       (Sn_MR_BRDB)
+#define SF_TCP_FPSH          (Sn_MR_FPSH)       ///< In TCP mode such as @ref Sn_MR_TCP4, @ref Sn_MR_TCP6 and @ref Sn_MR_TCPD, Use to forced push flag.
+
+#define SF_TCP_NODELAY       (Sn_MR_ND)       ///< In TCP mode such as @ref Sn_MR_TCP4, @ref Sn_MR_TCP6 and @ref Sn_MR_TCPD, Use to nodelayed ack.
+#define SF_IGMP_VER2         (Sn_MR_MC)       ///< In UDP mode such as @ref Sn_MR_UDP4 with @ref SF_MULTI_ENABLE, Select IGMP version 2.   
+#define SF_SOLICIT_BLOCK     (Sn_MR_SMB)      ///< In UDP mode such as @ref Sn_MR_UDP6 and @ref Sn_MR_UDPD, Block a solicited mutlicast packet.
+#define SF_ETHER_MULTI4B     (Sn_MR_MMB4)     ///< In MACRAW mode such as @ref Sn_MR_MACRAW with @ref SF_MULTI_ENABLE, Block a IPv4 multicast packet. 
+
+#define SF_UNI_BLOCK         (Sn_MR_UNIB)     ///< In UDP mdoe such as @ref Sn_MR_UDP4, @ref Sn_MR_UDP6 and @ref Sn_MR_UDPD with @ref SF_MULTI_ENABLE, Block a unicast packet. 
+#define SF_ETHER_MULIT6B     (Sn_MR_MMB6)     ///< In MACRAW mode such as @ref Sn_MR_MACRAW with @ref SF_MULTI_ENABLE, Block a IPv6 multicast packet. 
+
+/**
+    @brief Force to APR.
+    @details In datagram mode such as @ref Sn_MR_IPRAW4, @ref Sn_MR_IPRAW6, @ref Sn_MR_UDP4, @ref Sn_MR_UDP6, and @ref Sn_MR_UDPD,
+            Force to request ARP before a packet is sent to a destination.\n
+            In TCP mode such as @ref Sn_MR_TCP4, @ref Sn_MR_TCP6, and @ref Sn_MR_TCPD and <b>TCP SERVER</b> operation mode,
+            Force to request ARP before SYN/ACK packet is sent to a <b>TCP CLIENT</b>. \n
+            When @ref SF_DHA_MANUAL is set, the ARP is process but the destination hardware address is fixed by user.
+*/
+#define SF_FORCE_ARP         (Sn_MR2_FARP)
+
+/**
+    @brief The destination hardware address of packet to be transmitted is set by user through @ref _Sn_DHAR_. It is invalid in MACRAW mode such as @ref Sn_MR_MACRAW.
+*/
+#define SF_DHA_MANUAL        (Sn_MR2_DHAM)
+
+#define SF_IO_NONBLOCK       (0x01 << 3)     ///< Socket nonblock io mode. It used parameter in @ref socket().
+
+/*
+    UDP, IPRAW, MACRAW Packet Infomation
+*/
+#define PACK_IPv6            (1<<7)                ///< It indicates the destination IP address of the received packet is IPv6 or IPv4.
+#define PACK_IPV6_ALLNODE    (PACK_IPv6 | (1<<6))  ///< It indicates the destination IP address of the received packet is allnode multicast(broadcast) address or not.
+#define PACK_IPV6_MULTI      (PACK_IPv6 | (1<<5))  ///< It indicates the destination IP address of the received packet is multicast address or not.
+#define PACK_IPV6_LLA        (PACK_IPv6 | (1<<4))  ///< It indicates the destination IP address of the received packet is lla or gua.
+#define PACK_COMPLETED       (1<<3)                ///< It indicates the read data is last in the received packet.
+#define PACK_REMAINED        (1<<2)                ///< It indicates to remain data in the received packet
+#define PACK_FIRST           (1<<1)                ///< It indicates the read data is first in the received packet.
+#define PACK_NONE            (0x00)                ///< It indicates no information of a packet
+
+#define SRCV6_PREFER_AUTO    (PSR_AUTO)            ///< Soruce IPv6 address is preferred to auto-selection. Refer to @ref _Sn_PSR_
+#define SRCV6_PREFER_LLA     (PSR_LLA)             ///< Soruce IPv6 address is preferred to link local address. Refer to @ref _Sn_PSR_
+#define SRCV6_PREFER_GUA     (PSR_GUA)             ///< Soruce IPv6 address is preferred to global unique address. Refer to @ref _Sn_PSR_
+
+#define TCPSOCK_MODE         (Sn_ESR_TCPM)         ///< It indicates the IP version when SOCKETn is opened as TCP6 or TCPD mode.(0 - IPv4 , 1 - IPv6)
+#define TCPSOCK_OP           (Sn_ESR_TCPOP)        ///< It indicates the operation mode when SOCKETn is connected.(0 - <b>TCP CLIENT</b> , 1 - <b>TCP SERVER</b>)
+#define TCPSOCK_SIP          (Sn_ESR_IP6T)         ///< It indicates the source ip address type when SOCKET is connected. (0 - Link Local, 1 - Global Unique) 
+
+/////////////////////////////
+// SOCKET CONTROL & OPTION //
+/////////////////////////////
+#define SOCK_IO_BLOCK         0  ///< Socket Block IO Mode in @ref setsockopt().
+#define SOCK_IO_NONBLOCK      1  ///< Socket Non-block IO Mode in @ref setsockopt().
+#endif
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Open a socket.
+    @details Initializes the socket with 'sn' passed as parameter and open.
+
+    @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+    @param protocol Protocol type to operate such as TCP, UDP and MACRAW.
+    @param port Port number to be bined.
+    @param flag Socket flags as \ref SF_ETHER_OWN, \ref SF_IGMP_VER2, \ref SF_TCP_NODELAY, \ref SF_MULTI_ENABLE, \ref SF_IO_NONBLOCK and so on.\n
+               Valid flags only in W5500 : @ref SF_BROAD_BLOCK, @ref SF_MULTI_BLOCK, @ref SF_IPv6_BLOCK, and @ref SF_UNI_BLOCK.
+    @sa Sn_MR
+
+    @return @b Success : The socket number @b 'sn' passed as parameter\n
+           @b Fail    :\n @ref SOCKERR_SOCKNUM     - Invalid socket number\n
+                          @ref SOCKERR_SOCKMODE    - Not support socket mode as TCP, UDP, and so on. \n
+                          @ref SOCKERR_SOCKFLAG    - Invaild socket flag.
+*/
+int8_t  socket(uint8_t sn, uint8_t protocol, uint16_t port, uint8_t flag);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Close a socket.
+    @details It closes the socket  with @b'sn' passed as parameter.
+
+    @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+
+    @return @b Success : @ref SOCK_OK \n
+           @b Fail    : @ref SOCKERR_SOCKNUM - Invalid socket number
+*/
+int8_t  close(uint8_t sn);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Listen to a connection request from a client.
+    @details It is listening to a connection request from a client.
+    If connection request is accepted successfully, the connection is established. Socket sn is used in passive(server) mode.
+
+    @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+    @return @b Success : @ref SOCK_OK \n
+           @b Fail    :\n @ref SOCKERR_SOCKINIT   - Socket is not initialized \n
+                          @ref SOCKERR_SOCKCLOSED - Socket closed unexpectedly.
+*/
+int8_t  listen(uint8_t sn);
+
+//teddy 240122
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Try to connect to a <b>TCP SERVER</b>.
+    @details It sends a connection-reqeust message to the server with destination IP address and port number passed as parameter.\n
+            SOCKET <i>sn</i> is used as active(<b>TCP CLIENT</b>) mode.
+    @param sn SOCKET number. It should be <b>0 ~ @ref _WIZCHIP_SOCK_NUM_</b>.
+    @param addr Pointer variable of destination IPv6 or IPv4 address.
+    @param port Destination port number.
+    @param addrlen the length of <i>addr</i>. \n <- removed
+                  If addr is IPv6 address it should be 16,else if addr is IPv4 address it should be 4. Otherwize, return @ref SOCKERR_IPINVALID.
+    @return Success : @ref SOCK_OK \n
+           Fail    :\n @ref SOCKERR_SOCKNUM   - Invalid socket number\n
+                       @ref SOCKERR_SOCKMODE  - Invalid socket mode\n
+                       @ref SOCKERR_SOCKINIT  - Socket is not initialized\n
+                       @ref SOCKERR_IPINVALID - Wrong server IP address\n
+                       @ref SOCKERR_PORTZERO  - Server port zero\n
+                       @ref SOCKERR_TIMEOUT   - Timeout occurred during request connection\n
+                       @ref SOCK_BUSY         - In non-block io mode, it returns immediately\n
+    @note It is valid only in TCP client mode. \n
+         In block io mode, it does not return until connection is completed. \n
+         In Non-block io mode(@ref SF_IO_NONBLOCK), it returns @ref SOCK_BUSY immediately.
+*/
+static int8_t connect_IO_6(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
+//int8_t connect(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Try to disconnect a connection socket.
+    @details It sends request message to disconnect the TCP socket 'sn' passed as parameter to the server or client.
+    @note It is valid only in TCP server or client mode. \n
+         In block io mode, it does not return until disconnection is completed. \n
+         In Non-block io mode, it return @ref SOCK_BUSY immediately. \n
+
+    @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+    @return @b Success :   @ref SOCK_OK \n
+           @b Fail    :\n @ref SOCKERR_SOCKNUM  - Invalid socket number \n
+                          @ref SOCKERR_SOCKMODE - Invalid operation in the socket \n
+                          @ref SOCKERR_TIMEOUT  - Timeout occurred \n
+                          @ref SOCK_BUSY        - Socket is busy.
+*/
+int8_t  disconnect(uint8_t sn);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief	Send data to the connected peer in TCP socket.
+    @details It is used to send outgoing data to the connected socket.
+    @note    It is valid only in TCP server or client mode. It can't send data greater than socket buffer size. \n
+            In block io mode, It doesn't return until data send is completed - socket buffer size is greater than data. \n
+            In non-block io mode, It return @ref SOCK_BUSY immediately when socket buffer is not enough. \n
+    @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+    @param buf Pointer buffer containing data to be sent.
+    @param len The byte length of data in buf.
+    @return	@b Success : The sent data size \n
+            @b Fail    : \n @ref SOCKERR_SOCKSTATUS - Invalid socket status for socket operation \n
+                            @ref SOCKERR_TIMEOUT    - Timeout occurred \n
+                            @ref SOCKERR_SOCKMODE 	- Invalid operation in the socket \n
+                            @ref SOCKERR_SOCKNUM    - Invalid socket number \n
+                            @ref SOCKERR_DATALEN    - zero data length \n
+                            @ref SOCK_BUSY          - Socket is busy.
+*/
+int32_t send(uint8_t sn, uint8_t * buf, uint16_t len);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief	Receive data from the connected peer.
+    @details It is used to read incoming data from the connected socket.\n
+            It waits for data as much as the application wants to receive.
+    @note    It is valid only in TCP server or client mode. It can't receive data greater than socket buffer size. \n
+            In block io mode, it doesn't return until data reception is completed - data is filled as <I>len</I> in socket buffer. \n
+            In non-block io mode, it return @ref SOCK_BUSY immediately when <I>len</I> is greater than data size in socket buffer. \n
+
+    @param sn  Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
+    @param buf Pointer buffer to read incoming data.
+    @param len The max data length of data in buf.
+    @return	@b Success : The real received data size \n
+            @b Fail    :\n
+                       @ref SOCKERR_SOCKSTATUS - Invalid socket status for socket operation \n
+                       @ref SOCKERR_SOCKMODE   - Invalid operation in the socket \n
+                       @ref SOCKERR_SOCKNUM    - Invalid socket number \n
+                       @ref SOCKERR_DATALEN    - zero data length \n
+                       @ref SOCK_BUSY          - Socket is busy.
+*/
+int32_t recv(uint8_t sn, uint8_t * buf, uint16_t len);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Send datagram to the peer specifed by destination IP address and port number passed as parameter.
+    @details It sends datagram data by using UDP,IPRAW, or MACRAW mode SOCKET.
+    @param sn SOCKET number. It should be <b>0 ~ @ref _WIZCHIP_SOCK_NUM_</b>.
+    @param buf Pointer of data buffer to be sent.
+    @param len The byte length of data in buf.
+    @param addr Pointer variable of destination IPv6 or IPv4 address.
+    @param port Destination port number.
+    @param addrlen the length of <i>addr</i>. \n
+                  If addr is IPv6 address it should be 16,else if addr is IPv4 address it should be 4. Otherwize, return @ref SOCKERR_IPINVALID.
+    @return Success : The real sent data size. It may be equal to <i>len</i> or small.\n
+           Fail    :\n @ref SOCKERR_SOCKNUM     - Invalid SOCKET number \n
+                       @ref SOCKERR_SOCKMODE    - Invalid operation in the SOCKET \n
+                       @ref SOCKERR_SOCKSTATUS  - Invalid SOCKET status for SOCKET operation \n
+                       @ref SOCKERR_IPINVALID   - Invalid IP address\n
+                       @ref SOCKERR_PORTZERO    - Destination port number is zero\n
+                       @ref SOCKERR_DATALEN     - Invalid data length \n
+                       @ref SOCKERR_SOCKCLOSED  - SOCKET unexpectedly closed \n
+                       @ref SOCKERR_TIMEOUT     - Timeout occurred \n
+                       @ref SOCK_BUSY           - SOCKET is busy.
+    @note It is valid only in @ref Sn_MR_UDP4, @ref Sn_MR_UDP6, @ref Sn_MR_UDPD, @ref Sn_MR_IPRAW4, @ref Sn_MR_IPRAW6, and @ref Sn_MR_MACRAW. \n
+         In UDP mode, It can send data as many as SOCKET RX buffer size if data is greater than SOCKET TX buffer size. \n
+         In IPRAW and MACRAW mode, It should send data as many as MTU(maxium transmission unit) if data is greater than MTU. That is, <i>len</i> can't exceed to MTU.
+         In block io mode, It doesn't return until data send is completed.
+         In non-block io mode(@ref SF_IO_NONBLOCK), It return @ref SOCK_BUSY immediately when SOCKET transimttable buffer size is not enough.
+*/
+//int32_t sendto(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
+static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Receive datagram from a peer
+    @details It can read a data received from a peer by using UDP, IPRAW, or MACRAW mode SOCKET.
+    @param sn   SOCKET number. It should be <b>0 ~ @ref _WIZCHIP_SOCK_NUM_</b>.
+    @param buf  Pointer buffer to be saved the received data.
+    @param len  The max read data length. \n
+               When the received packet size <= <i>len</i>, it can read data as many as the packet size. \n
+               When others, it can read data as many as len and remain to the rest data of the packet.
+    @param addr Pointer variable of destination IP address.\n
+               It is valid only when @ref recvfrom() is first called for receiving the datagram packet.
+               You can check it valid or not through @ref PACK_FIRST. You can get it through @ref getsockopt(sn, @ref SO_PACKINFO, &packinfo).\n
+               In UDP4, IPRAW mode SOCKET, it should be allocated over 4bytes. \n
+               In UDP6, UDPD mode SOCKET, it should be allocated over 16bytes.
+    @param port Pointer variable of destination port number. \n
+               It is valid only when @ref recvfrom() is first called for receiving the datagram packet, same as <i>port</i> case.
+    @param addrlen The byte length of destination IP address. \n
+                  It is valid only when @ref recvfrom() is first called for receiving the datagram packet, same as <i>port</i> case.\n
+                  When the destination has a IPv4 address, it is set to 4. \n
+                  when the destination has a IPv6 address, it is set to 16.
+    @return   Success : The real received data size. It may be equal to <i>len</i> or small.\n
+            Fail    : @ref SOCKERR_SOCKMODE   - Invalid operation in the socket \n
+                      @ref SOCKERR_SOCKNUM    - Invalid socket number \n
+                      @ref SOCKERR_ARG        - Invalid parameter such as <i>addr</i>, <i>port</i>
+                      @ref SOCK_BUSY          - SOCKET is busy.
+    @note It is valid only in @ref Sn_MR_UDP4, @ref Sn_MR_UDP6, @ref Sn_MR_UDPD, @ref Sn_MR_IPRAW4, @ref Sn_MR_IPRAW6, and @ref Sn_MR_MACRAW. \n
+         When SOCKET is opened with @ref Sn_MR_MACRAW or When it reads the the remained data of the previous datagram packet,
+         the parameters such as <i>addr</i>, <i>port</i>, <i>addrlen</i> is ignored. \n
+         Also, It can read data as many as the received datagram packet size if <i>len</i> is greater than the datagram packet size. \n
+         In block io mode, it doesn't return until data reception is completed. that is, it waits until any datagram packet is received in SOCKET RX buffer. \n
+         In non-block io mode(@ref SF_IO_NONBLOCK), it return @ref SOCK_BUSY immediately when SOCKET RX buffer is empty. \n
+*/
+//int32_t recvfrom(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
+static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
+
+
+/////////////////////////////
+// SOCKET CONTROL & OPTION //
+/////////////////////////////
+#define SOCK_IO_BLOCK         0  ///< Socket Block IO Mode in @ref setsockopt().
+#define SOCK_IO_NONBLOCK      1  ///< Socket Non-block IO Mode in @ref setsockopt().
+
+/**
+    @defgroup DATA_TYPE DATA TYPE
+*/
+
+/**
+    @ingroup DATA_TYPE
+    @brief The kind of Socket Interrupt.
+    @sa Sn_IR, Sn_IMR, setSn_IR(), getSn_IR(), setSn_IMR(), getSn_IMR()
+*/
+typedef enum {
+    SIK_CONNECTED     = (1 << 0),    ///< connected
+    SIK_DISCONNECTED  = (1 << 1),    ///< disconnected
+    SIK_RECEIVED      = (1 << 2),    ///< data received
+    SIK_TIMEOUT       = (1 << 3),    ///< timeout occurred
+    SIK_SENT          = (1 << 4),    ///< send ok
+    //M20150410 : Remove the comma of last member
+    //SIK_ALL           = 0x1F,        ///< all interrupt
+    SIK_ALL           = 0x1F         ///< all interrupt
+} sockint_kind;
+
+/**
+    @ingroup DATA_TYPE
+    @brief The type of @ref ctlsocket().
+*/
+typedef enum {
+    CS_SET_IOMODE,          ///< set socket IO mode with @ref SOCK_IO_BLOCK or @ref SOCK_IO_NONBLOCK
+    CS_GET_IOMODE,          ///< get socket IO mode
+    CS_GET_MAXTXBUF,        ///< get the size of socket buffer allocated in TX memory
+    CS_GET_MAXRXBUF,        ///< get the size of socket buffer allocated in RX memory
+    CS_CLR_INTERRUPT,       ///< clear the interrupt of socket with @ref sockint_kind
+    CS_GET_INTERRUPT,       ///< get the socket interrupt. refer to @ref sockint_kind
+
+    //teddy 240122
+    //#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    CS_SET_PREFER,          ///< set the preferred source IPv6 address of transmission packet.\n Refer to @ref SRCV6_PREFER_AUTO, @ref SRCV6_PREFER_LLA and @ref SRCV6_PREFER_GUA.
+    CS_GET_PREFER,          ///< get the preferred source IPv6 address of transmission packet.\n Refer to @ref SRCV6_PREFER_AUTO, @ref SRCV6_PREFER_LLA and @ref SRCV6_PREFER_GUA.
+    //#endif
+#if _WIZCHIP_ >= 5100
+    CS_SET_INTMASK,         ///< set the interrupt mask of socket with @ref sockint_kind, Not supported in W5100
+    CS_GET_INTMASK          ///< get the masked interrupt of socket. refer to @ref sockint_kind, Not supported in W5100
+#endif
+} ctlsock_type;
+
+
+/**
+    @ingroup DATA_TYPE
+    @brief The type of socket option in @ref setsockopt() or @ref getsockopt()
+*/
+typedef enum {
+    SO_FLAG,           ///< Valid only in getsockopt(), For set flag of socket refer to <I>flag</I> in @ref socket().
+    SO_TTL,              ///< Set TTL. @ref Sn_TTL  ( @ref setSn_TTL(), @ref getSn_TTL() )
+    SO_TOS,              ///< Set TOS. @ref Sn_TOS  ( @ref setSn_TOS(), @ref getSn_TOS() )
+    SO_MSS,              ///< Set MSS. @ref Sn_MSSR ( @ref setSn_MSSR(), @ref getSn_MSSR() )
+    SO_DESTIP,           ///< Set the destination IP address. @ref Sn_DIPR ( @ref setSn_DIPR(), @ref getSn_DIPR() )
+    SO_DESTPORT,         ///< Set the destination Port number. @ref Sn_DPORT ( @ref setSn_DPORT(), @ref getSn_DPORT() )
+#if _WIZCHIP_ != 5100
+    SO_KEEPALIVESEND,    ///< Valid only in setsockopt. Manually send keep-alive packet in TCP mode, Not supported in W5100
+#if !( (_WIZCHIP_ == 5100) || (_WIZCHIP_ == 5200) )
+    SO_KEEPALIVEAUTO, ///< Set/Get keep-alive auto transmission timer in TCP mode, Not supported in W5100, W5200
+#endif
+#endif
+    SO_SENDBUF,          ///< Valid only in getsockopt. Get the free data size of Socekt TX buffer. @ref Sn_TX_FSR, @ref getSn_TX_FSR()
+    SO_RECVBUF,          ///< Valid only in getsockopt. Get the received data size in socket RX buffer. @ref Sn_RX_RSR, @ref getSn_RX_RSR()
+    SO_STATUS,           ///< Valid only in getsockopt. Get the socket status. @ref Sn_SR, @ref getSn_SR()
+
+    //teddy 240122
+    //#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    SO_EXTSTATUS,        ///< Valid only in @ref getsockopt(). Get the extended TCP SOCKETn status. @ref getSn_ESR()
+    SO_MODE,
+    //#endif
+    SO_REMAINSIZE,       ///< Valid only in getsockopt. Get the remained packet size in other then TCP mode.
+    SO_PACKINFO          ///< Valid only in getsockopt. Get the packet information as @ref PACK_FIRST, @ref PACK_REMAINED, and @ref PACK_COMPLETED in other then TCP mode.
+} sockopt_type;
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Control socket.
+    @details Control IO mode, Interrupt & Mask of socket and get the socket buffer information.
+             Refer to @ref ctlsock_type.
+    @param sn socket number
+    @param cstype type of control socket. refer to @ref ctlsock_type.
+    @param arg Data type and value is determined according to @ref ctlsock_type. \n
+               <table>
+                    <tr> <td> @b cstype </td> <td> @b data type</td><td>@b value</td></tr>
+                    <tr> <td> @ref CS_SET_IOMODE \n @ref CS_GET_IOMODE </td> <td> uint8_t </td><td>@ref SOCK_IO_BLOCK @ref SOCK_IO_NONBLOCK</td></tr>
+                    <tr> <td> @ref CS_GET_MAXTXBUF \n @ref CS_GET_MAXRXBUF </td> <td> uint16_t </td><td> 0 ~ 16K </td></tr>
+                    <tr> <td> @ref CS_CLR_INTERRUPT \n @ref CS_GET_INTERRUPT \n @ref CS_SET_INTMASK \n @ref CS_GET_INTMASK </td> <td> @ref sockint_kind </td><td> @ref SIK_CONNECTED, etc.  </td></tr>
+               </table>
+    @return @b Success @ref SOCK_OK \n
+            @b fail    @ref SOCKERR_ARG         - Invalid argument\n
+*/
+int8_t  ctlsocket(uint8_t sn, ctlsock_type cstype, void* arg);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief set socket options
+    @details Set socket option like as TTL, MSS, TOS, and so on. Refer to @ref sockopt_type.
+
+    @param sn socket number
+    @param sotype socket option type. refer to @ref sockopt_type
+    @param arg Data type and value is determined according to <I>sotype</I>. \n
+               <table>
+                    <tr> <td> @b sotype </td> <td> @b data type</td><td>@b value</td></tr>
+                    <tr> <td> @ref SO_TTL </td> <td> uint8_t </td><td> 0 ~ 255 </td> </tr>
+                    <tr> <td> @ref SO_TOS </td> <td> uint8_t </td><td> 0 ~ 255 </td> </tr>
+                    <tr> <td> @ref SO_MSS </td> <td> uint16_t </td><td> 0 ~ 65535 </td> </tr>
+                    <tr> <td> @ref SO_DESTIP </td> <td> uint8_t[4] </td><td>  </td></tr>
+                    <tr> <td> @ref SO_DESTPORT </td> <td> uint16_t </td><td> 0 ~ 65535 </td></tr>
+                    <tr> <td> @ref SO_KEEPALIVESEND </td> <td> null </td><td> null </td></tr>
+                    <tr> <td> @ref SO_KEEPALIVEAUTO </td> <td> uint8_t </td><td> 0 ~ 255 </td></tr>
+               </table>
+    @return
+    - @b Success : @ref SOCK_OK \n
+    - @b Fail
+    - @ref SOCKERR_SOCKNUM     - Invalid Socket number \n
+    - @ref SOCKERR_SOCKMODE    - Invalid socket mode \n
+    - @ref SOCKERR_SOCKOPT     - Invalid socket option or its value \n
+    - @ref SOCKERR_TIMEOUT     - Timeout occurred when sending keep-alive packet \n
+*/
+int8_t  setsockopt(uint8_t sn, sockopt_type sotype, void* arg);
+
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief get socket options
+    @details Get socket option like as FLAG, TTL, MSS, and so on. Refer to @ref sockopt_type
+    @param sn socket number
+    @param sotype socket option type. refer to @ref sockopt_type
+    @param arg Data type and value is determined according to <I>sotype</I>. \n
+               <table>
+                    <tr> <td> @b sotype </td> <td>@b data type</td><td>@b value</td></tr>
+                    <tr> <td> @ref SO_FLAG </td> <td> uint8_t </td><td> @ref SF_ETHER_OWN, etc... </td> </tr>
+                    <tr> <td> @ref SO_TOS </td> <td> uint8_t </td><td> 0 ~ 255 </td> </tr>
+                    <tr> <td> @ref SO_MSS </td> <td> uint16_t </td><td> 0 ~ 65535 </td> </tr>
+                    <tr> <td> @ref SO_DESTIP </td> <td> uint8_t[4] </td><td>  </td></tr>
+                    <tr> <td> @ref SO_DESTPORT </td> <td> uint16_t </td><td>  </td></tr>
+                    <tr> <td> @ref SO_KEEPALIVEAUTO </td> <td> uint8_t </td><td> 0 ~ 255 </td></tr>
+                    <tr> <td> @ref SO_SENDBUF </td> <td> uint16_t </td><td> 0 ~ 65535 </td></tr>
+                    <tr> <td> @ref SO_RECVBUF </td> <td> uint16_t </td><td> 0 ~ 65535 </td></tr>
+                    <tr> <td> @ref SO_STATUS </td> <td> uint8_t </td><td> @ref SOCK_ESTABLISHED, etc.. </td></tr>
+                    <tr> <td> @ref SO_REMAINSIZE </td> <td> uint16_t </td><td> 0~ 65535 </td></tr>
+                    <tr> <td> @ref SO_PACKINFO </td> <td> uint8_t </td><td> @ref PACK_FIRST, etc... </td></tr>
+               </table>
+    @return
+    - @b Success : @ref SOCK_OK \n
+    - @b Fail
+    - @ref SOCKERR_SOCKNUM     - Invalid Socket number \n
+    - @ref SOCKERR_SOCKOPT     - Invalid socket option or its value \n
+    - @ref SOCKERR_SOCKMODE    - Invalid socket mode \n
+    @note
+     The option as PACK_REMAINED and SO_PACKINFO is valid only in NON-TCP mode and after call @ref recvfrom(). \n
+     When SO_PACKINFO value is PACK_FIRST and the return value of recvfrom() is zero,
+     This means the zero byte UDP data(UDP Header only) received.
+*/
+int8_t  getsockopt(uint8_t sn, sockopt_type sotype, void* arg);
+
+//teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+/**
+    @ingroup WIZnet_socket_APIs
+    @brief Peeks a sub-message in SOCKETn RX buffer
+    @details It peeks the incoming message of SOCKETn RX buffer. \n
+             It can find the specified sub-message in the incoming message and
+             return the length of incoming message before the sub-message. \n
+             It is useful when you need to read each messages from multiple message in SOCKET RX buffer.
+    @param sn SOCKET number
+    @param submsg sub-message pointer to find
+    @param subsize the length of <i>submsg</i>
+    @return
+     - Success : the length of incoming message length before the <i>submsg</i> \n
+     - Fail : -1
+    @note
+     It is just return the length of incoming message before the found sub-message. It does not receive the message.\n
+     So, after calling peeksockmsg, @ref _Sn_RX_RD_ is not changed.
+*/
+int16_t peeksockmsg(uint8_t sn, uint8_t* submsg, uint16_t subsize);
+
+#endif
+
+// void setAddrlen_W6x00( uint8_t num) ;
+// uint8_t checkAddrlen_W6x00() ;
+
+// void inline_setAddrlen_W6x00( uint8_t num);
+// uint8_t inline_CheckAddrlen_W6x00( void );
+
+
+#if 1 // by_Lihan
+
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  by_Lihan_W5x00
+*/
+int8_t connect_W5x00(uint8_t sn, uint8_t * addr, uint16_t port);
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  by_Lihan_Wx00
+*/
+int8_t connect_W6x00(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
+
+
+
+
+
+#define GET_MACRO_connect(_1, _2, _3, _4, NAME, ...) NAME
+#define CHOOSE_TESTCODE_MACRO(...) GET_MACRO_connect(__VA_ARGS__, connect_4, connect_3)
+
+/**
+    // by_LIhan for overroading
+    // NOTE_LIHAN: Some sections of this code are not yet fully defined.
+     @note
+        In case of get 3 arguments - int8_t connect_W5x00(uint8_t sn, uint8_t * addr, uint16_t port  );\n
+        In case of get 4 arguments - int8_t connect_W6x00(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen );
+*/
+
+#define connect(...) CHOOSE_TESTCODE_MACRO(__VA_ARGS__)(__VA_ARGS__)
+
+//   In case of get 3 arguments
+#define connect_3(sn , addr , port ) connect_W5x00(sn , addr , port)
+
+//   In case of get 4 arguments
+#define connect_4(sn , addr , port, addrlen ) connect_W6x00(sn , addr , port,addrlen)
+
+
+
+
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  by_Lihan
+*/
+int32_t sendto_W5x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port);
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  by_Lihan
+*/
+int32_t sendto_W6x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
+
+
+#define GET_MACRO_sendto(_1, _2, _3, _4, _5 , _6, NAME, ...) NAME
+#define CHOOSE_sendto_MACRO(...) GET_MACRO_sendto(__VA_ARGS__, sendto_6, sendto_5)
+
+// by_LIhan for overroading
+// NOTE_LIHAN: Some sections of this code are not yet fully defined.
+//   In case of get 3 arguments - int8_t sendto_W5x00(uint8_t sn, uint8_t * addr, uint16_t port  );
+//   In case of get 4 arguments - int8_t sendto_W6x00(uint8_t sn, uint8_t * addr, uint16_t port,uint8_t addrlen );
+#define sendto(...) CHOOSE_sendto_MACRO(__VA_ARGS__)(__VA_ARGS__)
+
+//   In case of get 3 arguments
+#define sendto_5( sn,   buf,  len,  addr,  port ) sendto_W5x00( sn,   buf,  len,  addr,  port)
+
+//   In case of get 4 arguments
+#define sendto_6( sn,   buf,  len,  addr,  port, addrlen ) sendto_W6x00( sn,   buf,  len,  addr,  port, addrlen)
+
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  byLihan_W5x00
+*/
+int32_t recvfrom_W5x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port);
+/**
+     @ingroup WIZnet_socket_APIs
+     @brief  byLihan_Wx00
+*/
+int32_t recvfrom_W6x00(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port,  uint8_t *addrlen);
+
+
+#define GET_MACRO_recvfrom(_1, _2, _3, _4, _5, _6 ,NAME, ...) NAME
+#define CHOOSE_recvfrom_MACRO(...) GET_MACRO_recvfrom(__VA_ARGS__, recvfrom_6, recvfrom_5)
+
+// by_LIhanfor overroading
+// In case of get 3 arguments - int8_t recvfrom_W5x00(uint8_t sn, uint8_t * addr, uint16_t port  );
+// In case of get 4 arguments - int8_t recvfrom_W6x00(uint8_t sn, uint8_t * addr, uint16_t port,uint8_t addrlen );
+#define recvfrom(...) CHOOSE_recvfrom_MACRO(__VA_ARGS__)(__VA_ARGS__)
+
+//   In case of get 3 arguments
+#define recvfrom_5(sn,   buf,  len,  addr,  port ) recvfrom_W5x00(sn,   buf,  len,  addr,  port)
+
+//   In case of get 4 arguments
+#define recvfrom_6(sn,   buf,  len,  addr,  port, addrlen  ) recvfrom_W6x00(sn,   buf,  len,  addr,  port, addrlen )
+
+
+#endif
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif   // _SOCKET_H_
+
+

--- a/third_party/ioLibrary_Driver/Ethernet/wizchip_conf.c
+++ b/third_party/ioLibrary_Driver/Ethernet/wizchip_conf.c
@@ -1,0 +1,1515 @@
+//****************************************************************************/
+//!
+//! \file wizchip_conf.c
+//! \brief WIZCHIP Config Header File.
+//! \version 1.0.1
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2014/05/01> V1.0.1  Refer to M20140501
+//!        1. Explicit type casting in wizchip_bus_readdata() & wizchip_bus_writedata()
+//            Issued by Mathias ClauBen.
+//!           uint32_t type converts into ptrdiff_t first. And then recoverting it into uint8_t*
+//!           For remove the warning when pointer type size is not 32bit.
+//!           If ptrdiff_t doesn't support in your complier, You should must replace ptrdiff_t into your suitable pointer type.
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************/
+//A20140501 : for use the type - ptrdiff_t
+#include <stddef.h>
+//
+
+#include "wizchip_conf.h"
+
+/////////////
+//M20150401 : Remove ; in the default callback function such as wizchip_cris_enter(), wizchip_cs_select() and etc.
+/////////////
+
+/**
+    @brief Default function to enable interrupt.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	  wizchip_cris_enter(void)           {};
+void 	  wizchip_cris_enter(void)           {}
+
+/**
+    @brief Default function to disable interrupt.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	  wizchip_cris_exit(void)          {};
+void 	  wizchip_cris_exit(void)          {}
+
+/**
+    @brief Default function to select chip.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	wizchip_cs_select(void)            {};
+void 	wizchip_cs_select(void)            {}
+
+/**
+    @brief Default function to deselect chip.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	wizchip_cs_deselect(void)          {};
+void 	wizchip_cs_deselect(void)          {}
+
+/**
+    @brief Default function to read in direct or indirect interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//M20150601 : Rename the function for integrating with W5300
+//uint8_t wizchip_bus_readbyte(uint32_t AddrSel) { return * ((volatile uint8_t *)((ptrdiff_t) AddrSel)); }
+iodata_t wizchip_bus_readdata(uint32_t AddrSel) {
+    return * ((volatile iodata_t *)((ptrdiff_t) AddrSel));
+}
+
+/**
+    @brief Default function to write in direct or indirect interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//M20150601 : Rename the function for integrating with W5300
+//void 	wizchip_bus_writebyte(uint32_t AddrSel, uint8_t wb)  { *((volatile uint8_t*)((ptrdiff_t)AddrSel)) = wb; }
+void 	wizchip_bus_writedata(uint32_t AddrSel, iodata_t wb)  {
+    *((volatile iodata_t*)((ptrdiff_t)AddrSel)) = wb;
+}
+#if 1
+// 20231103 taylor
+/**
+    @brief Default function to read @ref iodata_t buffer by using BUS interface
+    @details @ref wizchip_bus_read_buf() provides the default read @ref iodata_t data as many as <i>len</i> from BUS of @ref _WIZCHIP_.
+    @param AddrSel It specifies the address of register to be read.
+    @param buf It specifies your buffer pointer to be saved the read data from @ref _WIZCHIP_.
+    @param len It specifies the data length to be read from @ref _WIZCHIP_.
+    @param addrinc It specifies whether the address is increased by every read operation or not.\n
+          0 : Not Increased \n
+          1 : Increased
+    @return void
+    @note It can be overwritten with your function or register your functions by calling @ref reg_wizchip_bus_cbfunc().
+    @sa wizchip_bus_write_buf()
+*/
+void wizchip_bus_read_buf(uint32_t AddrSel, iodata_t* buf, int16_t len, uint8_t addrinc) {
+    uint16_t i;
+    if (addrinc) {
+        addrinc = sizeof(iodata_t);
+    }
+    for (i = 0; i < len; i++) {
+        *buf++ = WIZCHIP.IF.BUS._read_data(AddrSel);
+        AddrSel += (uint32_t) addrinc;
+    }
+}
+
+/**
+    @brief Default function to write @ref iodata_t buffer by using BUS interface.
+    @details @ref wizchip_bus_write_buf() provides the default write @ref iodata_t data as many as <i>len</i> to BUS of @ref _WIZCHIP_.
+    @param AddrSel It specifies the address of register to be written.
+    @param buf It specifies your buffer pointer to be written to @ref _WIZCHIP_.
+    @param len It specifies the data length to be written to @ref _WIZCHIP_.
+    @param addrinc It specifies whether the address is increased by every write operation or not.\n
+          0 : Not Increased \n
+          1 : Increased
+    @return void
+    @note It can be overwritten with your function or register your functions by calling @ref reg_wizchip_bus_cbfunc().
+    @sa wizchip_bus_read_buf()
+*/
+void wizchip_bus_write_buf(uint32_t AddrSel, iodata_t* buf, int16_t len, uint8_t addrinc) {
+    uint16_t i;
+    if (addrinc) {
+        addrinc = sizeof(iodata_t);
+    }
+    for (i = 0; i < len ; i++) {
+        WIZCHIP.IF.BUS._write_data(AddrSel, *buf++);
+        AddrSel += (uint32_t)addrinc;
+    }
+
+}
+#endif
+
+/**
+    @brief Default function to read in SPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//uint8_t wizchip_spi_readbyte(void)        {return 0;};
+uint8_t wizchip_spi_readbyte(void)        {
+    return 0;
+}
+
+/**
+    @brief Default function to write in SPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	wizchip_spi_writebyte(uint8_t wb) {};
+void 	wizchip_spi_writebyte(uint8_t wb) {}
+
+/**
+    @brief Default function to burst read in SPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	wizchip_spi_readburst(uint8_t* pBuf, uint16_t len) 	{};
+#if 1
+// 20231018 taylor
+void 	wizchip_spi_readburst(uint8_t* pBuf, uint16_t len) {
+    for (uint16_t i = 0; i < len; i++) {
+        *pBuf++ = WIZCHIP.IF.SPI._read_byte();
+    }
+}
+#else
+void 	wizchip_spi_readburst(uint8_t* pBuf, uint16_t len) 	{}
+#endif
+
+/**
+    @brief Default function to burst write in SPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+//void 	wizchip_spi_writeburst(uint8_t* pBuf, uint16_t len) {};
+#if 1
+// 20231018 taylor
+void 	wizchip_spi_writeburst(uint8_t* pBuf, uint16_t len) {
+    for (uint16_t i = 0; i < len; i++) {
+        WIZCHIP.IF.SPI._write_byte(*pBuf++);
+    }
+}
+#else
+void 	wizchip_spi_writeburst(uint8_t* pBuf, uint16_t len) {}
+#endif
+#if 1   //teddy 240122
+
+/**
+    @brief Default function to read in QSPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+void wizchip_qspi_read(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) {}
+
+/**
+    @brief Default function to write in QSPI interface.
+    @note This function help not to access wrong address. If you do not describe this function or register any functions,
+    null function is called.
+*/
+void wizchip_qspi_write(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) {}
+
+#endif
+/**
+    @\ref _WIZCHIP instance
+*/
+//
+//M20150401 : For a compiler didnot support a member of structure
+//            Replace the assignment of struct members with the assingment of array
+//
+/*
+    _WIZCHIP  WIZCHIP =
+      {
+      .id                  = _WIZCHIP_ID_,
+      .if_mode             = _WIZCHIP_IO_MODE_,
+      .CRIS._enter         = wizchip_cris_enter,
+      .CRIS._exit          = wizchip_cris_exit,
+      .CS._select          = wizchip_cs_select,
+      .CS._deselect        = wizchip_cs_deselect,
+      .IF.BUS._read_byte   = wizchip_bus_readbyte,
+      .IF.BUS._write_byte  = wizchip_bus_writebyte
+    //    .IF.SPI._read_byte   = wizchip_spi_readbyte,
+    //    .IF.SPI._write_byte  = wizchip_spi_writebyte
+      };
+*/
+_WIZCHIP  WIZCHIP = {
+    _WIZCHIP_IO_MODE_,
+    _WIZCHIP_ID_,
+    {
+        wizchip_cris_enter,
+        wizchip_cris_exit
+    },
+    {
+        wizchip_cs_select,
+        wizchip_cs_deselect
+    },
+    {
+        {
+            //M20150601 : Rename the function
+            //wizchip_bus_readbyte,
+            //wizchip_bus_writebyte
+            wizchip_bus_readdata,
+            wizchip_bus_writedata
+        },
+
+    }
+};
+
+
+static uint8_t    _DNS_[4];      // DNS server ip address
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+static dhcp_mode  _DHCP_;        // DHCP mode
+//teddy 240122
+#elif ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+static uint8_t      _DNS6_[16];    ///< DSN server IPv6 address
+static ipconf_mode  _IPMODE_;      ///< IP configuration mode
+#endif
+
+void reg_wizchip_cris_cbfunc(void(*cris_en)(void), void(*cris_ex)(void)) {
+    if (!cris_en || !cris_ex) {
+        WIZCHIP.CRIS._enter = wizchip_cris_enter;
+        WIZCHIP.CRIS._exit  = wizchip_cris_exit;
+    } else {
+        WIZCHIP.CRIS._enter = cris_en;
+        WIZCHIP.CRIS._exit  = cris_ex;
+    }
+}
+
+void reg_wizchip_cs_cbfunc(void(*cs_sel)(void), void(*cs_desel)(void)) {
+    if (!cs_sel || !cs_desel) {
+        WIZCHIP.CS._select   = wizchip_cs_select;
+        WIZCHIP.CS._deselect = wizchip_cs_deselect;
+    } else {
+        WIZCHIP.CS._select   = cs_sel;
+        WIZCHIP.CS._deselect = cs_desel;
+    }
+}
+
+//M20150515 : For integrating with W5300
+//void reg_wizchip_bus_cbfunc(uint8_t(*bus_rb)(uint32_t addr), void (*bus_wb)(uint32_t addr, uint8_t wb))
+void reg_wizchip_bus_cbfunc(iodata_t(*bus_rb)(uint32_t addr), void (*bus_wb)(uint32_t addr, iodata_t wb)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_BUS_));
+    //M20150601 : Rename call back function for integrating with W5300
+    /*
+        if(!bus_rb || !bus_wb)
+        {
+        WIZCHIP.IF.BUS._read_byte   = wizchip_bus_readbyte;
+        WIZCHIP.IF.BUS._write_byte  = wizchip_bus_writebyte;
+        }
+        else
+        {
+        WIZCHIP.IF.BUS._read_byte   = bus_rb;
+        WIZCHIP.IF.BUS._write_byte  = bus_wb;
+        }
+    */
+    if (!bus_rb || !bus_wb) {
+        WIZCHIP.IF.BUS._read_data   = wizchip_bus_readdata;
+        WIZCHIP.IF.BUS._write_data  = wizchip_bus_writedata;
+    } else {
+        WIZCHIP.IF.BUS._read_data   = bus_rb;
+        WIZCHIP.IF.BUS._write_data  = bus_wb;
+    }
+}
+#if 1
+// 20231103 taylor
+void reg_wizchip_busbuf_cbfunc(void(*busbuf_rb)(uint32_t AddrSel, iodata_t* pBuf, int16_t len, uint8_t addrinc), void (*busbuf_wb)(uint32_t AddrSel, iodata_t* pBuf, int16_t len, uint8_t addrinc)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_BUS_));
+    //M20150601 : Rename call back function for integrating with W5300
+    /*
+        if(!bus_rb || !bus_wb)
+        {
+        WIZCHIP.IF.BUS._read_byte   = wizchip_bus_readbyte;
+        WIZCHIP.IF.BUS._write_byte  = wizchip_bus_writebyte;
+        }
+        else
+        {
+        WIZCHIP.IF.BUS._read_byte   = bus_rb;
+        WIZCHIP.IF.BUS._write_byte  = bus_wb;
+        }
+    */
+    if (!busbuf_rb || !busbuf_wb) {
+        WIZCHIP.IF.BUS._read_data_buf   = wizchip_bus_read_buf;
+        WIZCHIP.IF.BUS._write_data_buf  = wizchip_bus_write_buf;
+    } else {
+        WIZCHIP.IF.BUS._read_data_buf   = busbuf_rb;
+        WIZCHIP.IF.BUS._write_data_buf  = busbuf_wb;
+    }
+}
+#endif
+
+#if _WIZCHIP_ == W6100
+
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void),
+                            void (*spi_wb)(uint8_t wb),
+                            void (*spi_rbuf)(uint8_t* buf, datasize_t len),
+                            void (*spi_wbuf)(uint8_t* buf, datasize_t len)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_SPI_));
+
+    if (!spi_rb) {
+        WIZCHIP.IF.SPI._read_byte      = wizchip_spi_readbyte;
+    } else {
+        WIZCHIP.IF.SPI._read_byte      = spi_rb;
+    }
+    if (!spi_wb) {
+        WIZCHIP.IF.SPI._write_byte     = wizchip_spi_writebyte;
+    } else {
+        WIZCHIP.IF.SPI._write_byte     = spi_wb;
+    }
+
+    if (!spi_rbuf) {
+        WIZCHIP.IF.SPI._read_burst  = wizchip_spi_readburst;
+    } else {
+        WIZCHIP.IF.SPI._read_burst  = spi_rbuf;
+    }
+    if (!spi_wbuf) {
+        WIZCHIP.IF.SPI._write_burst = wizchip_spi_writeburst;
+    } else {
+        WIZCHIP.IF.SPI._write_burst = spi_wbuf;
+    }
+}
+#else
+
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), void (*spi_wb)(uint8_t wb)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_SPI_));
+
+    if (!spi_rb || !spi_wb) {
+        WIZCHIP.IF.SPI._read_byte   = wizchip_spi_readbyte;
+        WIZCHIP.IF.SPI._write_byte  = wizchip_spi_writebyte;
+    } else {
+        WIZCHIP.IF.SPI._read_byte   = spi_rb;
+        WIZCHIP.IF.SPI._write_byte  = spi_wb;
+    }
+}
+#endif
+
+// 20140626 Eric Added for SPI burst operations
+void reg_wizchip_spiburst_cbfunc(void (*spi_rb)(uint8_t* pBuf, uint16_t len), void (*spi_wb)(uint8_t* pBuf, uint16_t len)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_SPI_));
+
+    if (!spi_rb || !spi_wb) {
+        WIZCHIP.IF.SPI._read_burst   = wizchip_spi_readburst;
+        WIZCHIP.IF.SPI._write_burst  = wizchip_spi_writeburst;
+    } else {
+        WIZCHIP.IF.SPI._read_burst   = spi_rb;
+        WIZCHIP.IF.SPI._write_burst  = spi_wb;
+    }
+}
+#if 1 //teddy 240122
+void reg_wizchip_qspi_cbfunc(void (*qspi_rb)(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len),
+                             void (*qspi_wb)(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len)) {
+    while (!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_SPI_QSPI_));
+
+    if (!qspi_rb || !qspi_wb) {
+        WIZCHIP.IF.QSPI._read_qspi   = wizchip_qspi_read;
+        WIZCHIP.IF.QSPI._write_qspi  = wizchip_qspi_write;
+    } else {
+        WIZCHIP.IF.QSPI._read_qspi   = qspi_rb;
+        WIZCHIP.IF.QSPI._write_qspi  = qspi_wb;
+    }
+}
+#endif
+
+int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg) {
+    //teddy 240122
+#if	_WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    uint8_t tmp = *(uint8_t*) arg;
+#endif
+    uint8_t* ptmp[2] = {0, 0};
+    switch (cwtype) {
+        //teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    case CW_SYS_LOCK:
+        if (tmp & SYS_CHIP_LOCK) {
+            CHIPLOCK();
+        }
+        if (tmp & SYS_NET_LOCK) {
+            NETLOCK();
+        }
+        if (tmp & SYS_PHY_LOCK) {
+            PHYLOCK();
+        }
+        break;
+    case CW_SYS_UNLOCK:
+        if (tmp & SYS_CHIP_LOCK) {
+            CHIPUNLOCK();
+        }
+        if (tmp & SYS_NET_LOCK) {
+            NETUNLOCK();
+        }
+        if (tmp & SYS_PHY_LOCK) {
+            PHYUNLOCK();
+        }
+        break;
+    case CW_GET_SYSLOCK:
+        *(uint8_t*)arg = getSYSR() >> 5;
+        break;
+#endif
+    case CW_RESET_WIZCHIP:
+        wizchip_sw_reset();
+        break;
+    case CW_INIT_WIZCHIP:
+        if (arg != 0) {
+            ptmp[0] = (uint8_t*)arg;
+            ptmp[1] = ptmp[0] + _WIZCHIP_SOCK_NUM_;
+        }
+        return wizchip_init(ptmp[0], ptmp[1]);
+    case CW_CLR_INTERRUPT:
+        wizchip_clrinterrupt(*((intr_kind*)arg));
+        break;
+    case CW_GET_INTERRUPT:
+        *((intr_kind*)arg) = wizchip_getinterrupt();
+        break;
+    case CW_SET_INTRMASK:
+        wizchip_setinterruptmask(*((intr_kind*)arg));
+        break;
+    case CW_GET_INTRMASK:
+        *((intr_kind*)arg) = wizchip_getinterruptmask();
+        break;
+        //M20150601 : This can be supported by W5200, W5500
+        //#if _WIZCHIP_ > W5100
+#if (_WIZCHIP_ == W5200 || _WIZCHIP_ == W5500)
+    case CW_SET_INTRTIME:
+        setINTLEVEL(*(uint16_t*)arg);
+        break;
+    case CW_GET_INTRTIME:
+        *(uint16_t*)arg = getINTLEVEL();
+        break;
+        //teddy 240122
+#elif ((_WIZCHIP_ == W6100) || (_WIZCHIP_ == W6300))
+    case CW_SET_INTRTIME:
+        setINTPTMR(*(uint16_t*)arg);
+        break;
+    case CW_GET_INTRTIME:
+        *(uint16_t*)arg = getINTPTMR();
+        break;
+#endif
+    case CW_GET_ID:
+        ((uint8_t*)arg)[0] = WIZCHIP.id[0];
+        ((uint8_t*)arg)[1] = WIZCHIP.id[1];
+        ((uint8_t*)arg)[2] = WIZCHIP.id[2];
+        ((uint8_t*)arg)[3] = WIZCHIP.id[3];
+        ((uint8_t*)arg)[4] = WIZCHIP.id[4];
+        ((uint8_t*)arg)[5] = WIZCHIP.id[5];
+        ((uint8_t*)arg)[6] = 0;
+        break;
+#if 1
+        // 20231017 taylor//teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    case CW_GET_VER:
+        *(uint16_t*)arg = getVER();
+        break;
+#endif
+#endif
+        //teddy 240122
+#if _WIZCHIP_ == W5100S || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    case CW_RESET_PHY:
+        wizphy_reset();
+        break;
+    case CW_SET_PHYCONF:
+        wizphy_setphyconf((wiz_PhyConf*)arg);
+        break;
+    case CW_GET_PHYCONF:
+        wizphy_getphyconf((wiz_PhyConf*)arg);
+        break;
+    case CW_GET_PHYSTATUS:
+#if 1
+        // 20231012 taylor
+#if _WIZCHIP_ == W5500
+        wizphy_getphystat((wiz_PhyConf*)arg);
+#endif
+#else
+        wizphy_getphystat((wiz_PhyConf*)arg);
+#endif
+        break;
+    case CW_SET_PHYPOWMODE:
+        //teddy 240122
+#if _WIZCHIP_ == W6100 ||_WIZCHIP_ == W6300
+        wizphy_setphypmode(*(uint8_t*)arg);
+        break;
+#else
+        return wizphy_setphypmode(*(uint8_t*)arg);
+#endif
+#endif
+        //teddy 240122
+#if _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    case CW_GET_PHYPOWMODE:
+        tmp = wizphy_getphypmode();
+        if ((int8_t)tmp == -1) {
+            return -1;
+        }
+        *(uint8_t*)arg = tmp;
+        break;
+    case CW_GET_PHYLINK:
+        tmp = wizphy_getphylink();
+        if ((int8_t)tmp == -1) {
+            return -1;
+        }
+        *(uint8_t*)arg = tmp;
+        break;
+#endif
+    default:
+        return -1;
+    }
+    return 0;
+}
+
+
+int8_t ctlnetwork(ctlnetwork_type cntype, void* arg) {
+
+    switch (cntype) {
+    case CN_SET_NETINFO:
+        wizchip_setnetinfo((wiz_NetInfo*)arg);
+        break;
+    case CN_GET_NETINFO:
+        wizchip_getnetinfo((wiz_NetInfo*)arg);
+        break;
+    case CN_SET_NETMODE:
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+        return wizchip_setnetmode(*(netmode_type*)arg);
+        //teddy 240122
+#elif ((_WIZCHIP_ == 6100)||(_WIZCHIP_ == W6300))
+        wizchip_setnetmode(*(netmode_type*)arg);
+#endif
+    case CN_GET_NETMODE:
+        *(netmode_type*)arg = wizchip_getnetmode();
+        break;
+    case CN_SET_TIMEOUT:
+        wizchip_settimeout((wiz_NetTimeout*)arg);
+        break;
+    case CN_GET_TIMEOUT:
+        wizchip_gettimeout((wiz_NetTimeout*)arg);
+        break;
+        //teddy 240122
+#if ((_WIZCHIP_ == 6100)||(_WIZCHIP_ == 6300))
+    case CN_SET_PREFER:
+        setSLPSR(*(uint8_t*)arg);
+        break;
+    case CN_GET_PREFER:
+        *(uint8_t*)arg = getSLPSR();
+        break;
+#endif
+    default:
+        return -1;
+    }
+    return 0;
+}
+
+void wizchip_sw_reset(void) {
+    uint8_t gw[4], sn[4], sip[4];
+    uint8_t mac[6];
+    //teddy 240122
+#if ((_WIZCHIP_ == 6100) ||(_WIZCHIP_ == 6300))
+    uint8_t gw6[16], sn6[16], lla[16], gua[16];
+    uint8_t islock = getSYSR();
+#endif
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+    //A20150601
+#if _WIZCHIP_IO_MODE_  == _WIZCHIP_IO_MODE_BUS_INDIR_
+    uint16_t mr = (uint16_t)getMR();
+    setMR(mr | MR_IND);
+#endif
+    //
+    getSHAR(mac);
+    getGAR(gw);  getSUBR(sn);  getSIPR(sip);
+    setMR(MR_RST);
+    getMR(); // for delay
+    //A2015051 : For indirect bus mode
+#if _WIZCHIP_IO_MODE_  == _WIZCHIP_IO_MODE_BUS_INDIR_
+    setMR(mr | MR_IND);
+#endif
+    //
+    setSHAR(mac);
+    setGAR(gw);
+    setSUBR(sn);
+    setSIPR(sip);
+    //teddy 240122
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+    CHIPUNLOCK();
+
+    getSHAR(mac);
+    getGAR(gw);  getSUBR(sn);  getSIPR(sip); getGA6R(gw6); getSUB6R(sn6); getLLAR(lla); getGUAR(gua);
+    setSYCR0(SYCR0_RST);
+    getSYCR0(); // for delay
+
+    NETUNLOCK();
+
+    setSHAR(mac);
+    setGAR(gw);
+    setSUBR(sn);
+    setSIPR(sip);
+    setGA6R(gw6);
+    setSUB6R(sn6);
+    setLLAR(lla);
+    setGUAR(gua);
+    if (islock & SYSR_CHPL) {
+        CHIPLOCK();
+    }
+    if (islock & SYSR_NETL) {
+        NETLOCK();
+    }
+#endif
+}
+
+int8_t wizchip_init(uint8_t* txsize, uint8_t* rxsize) {
+    int8_t i;
+#if _WIZCHIP_ < W5200
+    int8_t j;
+#endif
+    int8_t tmp = 0;
+    wizchip_sw_reset();
+    if (txsize) {
+        tmp = 0;
+        //M20150601 : For integrating with W5300
+#if _WIZCHIP_ == W5300
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+            if (txsize[i] > 64) {
+                return -1;    //No use 64KB even if W5300 support max 64KB memory allocation
+            }
+            tmp += txsize[i];
+            if (tmp > 128) {
+                return -1;
+            }
+        }
+        if (tmp % 8) {
+            return -1;
+        }
+#else
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+            tmp += txsize[i];
+
+#if _WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
+            if (tmp > 8) {
+                return -1;
+            }
+#elif  _WIZCHIP_ == W6300
+            if (tmp > 32) {
+                return -1;
+            }
+#else
+            if (tmp > 16) {
+                return -1;
+            }
+#endif
+        }
+#endif
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+#if _WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100
+            j = 0;
+            while ((txsize[i] >> j != 1) && (txsize[i] != 0)) {
+                j++;
+            }
+            setSn_TXBUF_SIZE(i, j);
+#else
+            setSn_TXBUF_SIZE(i, txsize[i]);
+#endif
+        }
+    }
+
+    if (rxsize) {
+        tmp = 0;
+#if _WIZCHIP_ == W5300
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+            if (rxsize[i] > 64) {
+                return -1;    //No use 64KB even if W5300 support max 64KB memory allocation
+            }
+            tmp += rxsize[i];
+            if (tmp > 128) {
+                return -1;
+            }
+        }
+        if (tmp % 8) {
+            return -1;
+        }
+#else
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+            tmp += rxsize[i];
+#if _WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
+            if (tmp > 8) {
+                return -1;
+            }
+#elif  _WIZCHIP_ == W6300
+            if (tmp > 32) {
+                return -1;
+            }
+#else
+            if (tmp > 16) {
+                return -1;
+            }
+#endif
+        }
+#endif
+        for (i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++) {
+#if _WIZCHIP_ < W5200	// add condition for w5100
+            j = 0;
+            while ((rxsize[i] >> j != 1) && (txsize[i] != 0)) {
+                j++;
+            }
+            setSn_RXBUF_SIZE(i, j);
+#else
+            setSn_RXBUF_SIZE(i, rxsize[i]);
+#endif
+        }
+    }
+    return 0;
+}
+
+void wizchip_clrinterrupt(intr_kind intr) {
+    uint8_t ir  = (uint8_t)intr;
+    uint8_t sir = (uint8_t)((uint16_t)intr >> 8);
+
+    //teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    int i;
+    uint8_t slir = (uint8_t)((uint32_t)intr >> 16);
+    setIRCLR(ir);
+    for (i = 0; i < _WIZCHIP_SOCK_NUM_; i++) {
+        if (sir & (1 << i)) {
+            setSn_IRCLR(i, 0xFF);
+        }
+    }
+    setSLIRCLR(slir);
+    return;
+#endif
+
+#if _WIZCHIP_ < W5500
+    ir |= (1 << 4); // IK_WOL
+#endif
+#if _WIZCHIP_ == W5200
+    ir |= (1 << 6);
+#endif
+
+#if _WIZCHIP_ < W5200
+    sir &= 0x0F;
+#endif
+
+#if _WIZCHIP_ <= W5100S
+    ir |= sir;
+    setIR(ir);
+    //A20150601 : For integrating with W5300
+#elif _WIZCHIP_ == W5300
+    setIR(((((uint16_t)ir) << 8) | (((uint16_t)sir) & 0x00FF)));
+#else
+    setIR(ir);
+    //M20200227 : For clear
+    //setSIR(sir);
+    for (ir = 0; ir < 8; ir++) {
+        if (sir & (0x01 << ir)) {
+            setSn_IR(ir, 0xff);
+        }
+    }
+
+#endif
+}
+
+intr_kind wizchip_getinterrupt(void) {
+    uint8_t ir  = 0;
+    uint8_t sir = 0;
+    uint32_t ret = 0;
+
+#if _WIZCHIP_ <= W5100S
+    ir = getIR();
+    sir = ir & 0x0F;
+    //A20150601 : For integrating with W5300
+#elif _WIZCHIP_  == W5300
+    ret = getIR();
+    ir = (uint8_t)(ret >> 8);
+    sir = (uint8_t)ret;
+#else
+    ir  = getIR();
+    sir = getSIR();
+#endif
+
+    //M20150601 : For Integrating with W5300
+    //#if _WIZCHIP_ < W5500
+#if _WIZCHIP_ < W5200
+    ir &= ~(1 << 4); // IK_WOL
+#endif
+#if _WIZCHIP_ == W5200
+    ir &= ~(1 << 6);
+#endif
+    ret = sir;
+    ret = (ret << 8) + ir;
+    //teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    ret = (((uint32_t)getSLIR()) << 16) | ret;
+#endif
+
+    return (intr_kind)ret;
+}
+
+void wizchip_setinterruptmask(intr_kind intr) {
+    uint8_t imr  = (uint8_t)intr;
+    uint8_t simr = (uint8_t)((uint16_t)intr >> 8);
+#if _WIZCHIP_ < W5500
+    imr &= ~(1 << 4); // IK_WOL
+#endif
+#if _WIZCHIP_ == W5200
+    imr &= ~(1 << 6);
+#endif
+
+#if _WIZCHIP_ < W5200
+    simr &= 0x0F;
+    imr |= simr;
+    setIMR(imr);
+    //A20150601 : For integrating with W5300
+#elif _WIZCHIP_ == W5300
+    setIMR(((((uint16_t)imr) << 8) | (((uint16_t)simr) & 0x00FF)));
+#else
+    setIMR(imr);
+    setSIMR(simr);
+    //teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    uint8_t slimr = (uint8_t)((uint32_t)intr >> 16);
+    setSLIMR(slimr);
+#endif
+#endif
+}
+
+intr_kind wizchip_getinterruptmask(void) {
+    uint8_t imr  = 0;
+    uint8_t simr = 0;
+    uint32_t ret = 0;
+#if _WIZCHIP_ < W5200
+    imr  = getIMR();
+    simr = imr & 0x0F;
+    //A20150601 : For integrating with W5300
+#elif _WIZCHIP_ == W5300
+    ret = getIMR();
+    imr = (uint8_t)(ret >> 8);
+    simr = (uint8_t)ret;
+#else
+    imr  = getIMR();
+    simr = getSIMR();
+#endif
+
+#if _WIZCHIP_ < W5500
+    imr &= ~(1 << 4); // IK_WOL
+#endif
+#if _WIZCHIP_ == W5200
+    imr &= ~(1 << 6);  // IK_DEST_UNREACH
+#endif
+    ret = simr;
+    ret = (ret << 8) + imr;
+
+    //teddy 240122
+#if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+    ret = (((uint32_t)getSLIMR()) << 16) | ret;
+#endif
+
+    return (intr_kind)ret;
+}
+
+int8_t wizphy_getphylink(void) {
+    int8_t tmp = PHY_LINK_OFF;
+#if _WIZCHIP_ == W5100S
+    if (getPHYSR() & PHYSR_LNK) {
+        tmp = PHY_LINK_ON;
+    }
+#elif   _WIZCHIP_ == W5200
+    if (getPHYSTATUS() & PHYSTATUS_LINK) {
+        tmp = PHY_LINK_ON;
+    }
+#elif _WIZCHIP_ == W5500
+    if (getPHYCFGR() & PHYCFGR_LNK_ON) {
+        tmp = PHY_LINK_ON;
+    }
+
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    return (getPHYSR() & PHYSR_LNK);
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    if (wiz_mdio_read(PHYRAR_BMSR) & BMSR_LINK_STATUS) {
+        return PHY_LINK_ON;
+    }
+    return PHY_LINK_OFF;
+#endif
+
+#else
+    tmp = -1;
+#endif
+    return tmp;
+}
+
+#if _WIZCHIP_ > W5100
+
+int8_t wizphy_getphypmode(void) {
+    int8_t tmp = 0;
+#if   _WIZCHIP_ == W5200
+    if (getPHYSTATUS() & PHYSTATUS_POWERDOWN) {
+        tmp = PHY_POWER_DOWN;
+    } else {
+        tmp = PHY_POWER_NORM;
+    }
+#elif _WIZCHIP_ == 5500
+    if ((getPHYCFGR() & PHYCFGR_OPMDC_ALLA) == PHYCFGR_OPMDC_PDOWN) {
+        tmp = PHY_POWER_DOWN;
+    } else {
+        tmp = PHY_POWER_NORM;
+    }
+    //teddy 240122
+#elif _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    if (getPHYCR1() & PHYCR1_PWDN) {
+        return PHY_POWER_DOWN;
+    }
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    if (wiz_mdio_read(PHYRAR_BMCR) & BMCR_PWDN) {
+        return PHY_POWER_DOWN;
+    }
+#endif
+    return PHY_POWER_NORM;
+#else
+    tmp = -1;
+#endif
+    return tmp;
+}
+#endif
+
+#if _WIZCHIP_ == W5100S
+void wizphy_reset(void) {
+    uint16_t tmp = wiz_mdio_read(PHYMDIO_BMCR);
+    tmp |= BMCR_RESET;
+    wiz_mdio_write(PHYMDIO_BMCR, tmp);
+    while (wiz_mdio_read(PHYMDIO_BMCR)&BMCR_RESET) {}
+}
+
+void wizphy_setphyconf(wiz_PhyConf* phyconf) {
+    uint16_t tmp = wiz_mdio_read(PHYMDIO_BMCR);
+    if (phyconf->mode == PHY_MODE_AUTONEGO) {
+        tmp |= BMCR_AUTONEGO;
+    } else {
+        tmp &= ~BMCR_AUTONEGO;
+        if (phyconf->duplex == PHY_DUPLEX_FULL) {
+            tmp |= BMCR_DUP;
+        } else {
+            tmp &= ~BMCR_DUP;
+        }
+        if (phyconf->speed == PHY_SPEED_100) {
+            tmp |= BMCR_SPEED;
+        } else {
+            tmp &= ~BMCR_SPEED;
+        }
+    }
+    wiz_mdio_write(PHYMDIO_BMCR, tmp);
+}
+
+void wizphy_getphyconf(wiz_PhyConf* phyconf) {
+    uint16_t tmp = 0;
+    tmp = wiz_mdio_read(PHYMDIO_BMCR);
+    phyconf->by   = PHY_CONFBY_SW;
+    if (tmp & BMCR_AUTONEGO) {
+        phyconf->mode = PHY_MODE_AUTONEGO;
+    } else {
+        phyconf->mode = PHY_MODE_MANUAL;
+        if (tmp & BMCR_DUP) {
+            phyconf->duplex = PHY_DUPLEX_FULL;
+        } else {
+            phyconf->duplex = PHY_DUPLEX_HALF;
+        }
+        if (tmp & BMCR_SPEED) {
+            phyconf->speed = PHY_SPEED_100;
+        } else {
+            phyconf->speed = PHY_SPEED_10;
+        }
+    }
+}
+
+int8_t wizphy_setphypmode(uint8_t pmode) {
+    uint16_t tmp = 0;
+    tmp = wiz_mdio_read(PHYMDIO_BMCR);
+    if (pmode == PHY_POWER_DOWN) {
+        tmp |= BMCR_PWDN;
+    } else {
+        tmp &= ~BMCR_PWDN;
+    }
+    wiz_mdio_write(PHYMDIO_BMCR, tmp);
+    tmp = wiz_mdio_read(PHYMDIO_BMCR);
+    if (pmode == PHY_POWER_DOWN) {
+        if (tmp & BMCR_PWDN) {
+            return 0;
+        }
+    } else {
+        if ((tmp & BMCR_PWDN) != BMCR_PWDN) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+#elif _WIZCHIP_ == W5500
+void wizphy_reset(void) {
+    uint8_t tmp = getPHYCFGR();
+    tmp &= PHYCFGR_RST;
+    setPHYCFGR(tmp);
+    tmp = getPHYCFGR();
+    tmp |= ~PHYCFGR_RST;
+    setPHYCFGR(tmp);
+}
+
+void wizphy_setphyconf(wiz_PhyConf* phyconf) {
+    uint8_t tmp = 0;
+    if (phyconf->by == PHY_CONFBY_SW) {
+        tmp |= PHYCFGR_OPMD;
+    } else {
+        tmp &= ~PHYCFGR_OPMD;
+    }
+    if (phyconf->mode == PHY_MODE_AUTONEGO) {
+        tmp |= PHYCFGR_OPMDC_ALLA;
+    } else {
+        if (phyconf->duplex == PHY_DUPLEX_FULL) {
+            if (phyconf->speed == PHY_SPEED_100) {
+                tmp |= PHYCFGR_OPMDC_100F;
+            } else {
+                tmp |= PHYCFGR_OPMDC_10F;
+            }
+        } else {
+            if (phyconf->speed == PHY_SPEED_100) {
+                tmp |= PHYCFGR_OPMDC_100H;
+            } else {
+                tmp |= PHYCFGR_OPMDC_10H;
+            }
+        }
+    }
+    setPHYCFGR(tmp);
+    wizphy_reset();
+}
+
+void wizphy_getphyconf(wiz_PhyConf* phyconf) {
+    uint8_t tmp = 0;
+    tmp = getPHYCFGR();
+    phyconf->by   = (tmp & PHYCFGR_OPMD) ? PHY_CONFBY_SW : PHY_CONFBY_HW;
+    switch (tmp & PHYCFGR_OPMDC_ALLA) {
+    case PHYCFGR_OPMDC_ALLA:
+    case PHYCFGR_OPMDC_100FA:
+        phyconf->mode = PHY_MODE_AUTONEGO;
+        break;
+    default:
+        phyconf->mode = PHY_MODE_MANUAL;
+        break;
+    }
+    switch (tmp & PHYCFGR_OPMDC_ALLA) {
+    case PHYCFGR_OPMDC_100FA:
+    case PHYCFGR_OPMDC_100F:
+    case PHYCFGR_OPMDC_100H:
+        phyconf->speed = PHY_SPEED_100;
+        break;
+    default:
+        phyconf->speed = PHY_SPEED_10;
+        break;
+    }
+    switch (tmp & PHYCFGR_OPMDC_ALLA) {
+    case PHYCFGR_OPMDC_100FA:
+    case PHYCFGR_OPMDC_100F:
+    case PHYCFGR_OPMDC_10F:
+        phyconf->duplex = PHY_DUPLEX_FULL;
+        break;
+    default:
+        phyconf->duplex = PHY_DUPLEX_HALF;
+        break;
+    }
+}
+
+void wizphy_getphystat(wiz_PhyConf* phyconf) {
+    uint8_t tmp = getPHYCFGR();
+    phyconf->duplex = (tmp & PHYCFGR_DPX_FULL) ? PHY_DUPLEX_FULL : PHY_DUPLEX_HALF;
+    phyconf->speed  = (tmp & PHYCFGR_SPD_100) ? PHY_SPEED_100 : PHY_SPEED_10;
+}
+
+int8_t wizphy_setphypmode(uint8_t pmode) {
+    uint8_t tmp = 0;
+    tmp = getPHYCFGR();
+    if ((tmp & PHYCFGR_OPMD) == 0) {
+        return -1;
+    }
+    tmp &= ~PHYCFGR_OPMDC_ALLA;
+    if (pmode == PHY_POWER_DOWN) {
+        tmp |= PHYCFGR_OPMDC_PDOWN;
+    } else {
+        tmp |= PHYCFGR_OPMDC_ALLA;
+    }
+    setPHYCFGR(tmp);
+    wizphy_reset();
+    tmp = getPHYCFGR();
+    if (pmode == PHY_POWER_DOWN) {
+        if (tmp & PHYCFGR_OPMDC_PDOWN) {
+            return 0;
+        }
+    } else {
+        if (tmp & PHYCFGR_OPMDC_ALLA) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+//teddy 240122
+#elif _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+void wizphy_reset(void) {
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    uint8_t tmp = getPHYCR1() | PHYCR1_RST;
+    PHYUNLOCK();
+    setPHYCR1(tmp);
+    PHYLOCK();
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    wiz_mdio_write(PHYRAR_BMCR, wiz_mdio_read(PHYRAR_BMCR) | BMCR_RST);
+    while (wiz_mdio_read(PHYRAR_BMCR) & BMCR_RST);
+#endif
+}
+
+void wizphy_setphyconf(wiz_PhyConf* phyconf) {
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    uint8_t tmp = 0;
+    if (phyconf->mode == PHY_MODE_TE) {
+        setPHYCR1(getPHYCR1() | PHYCR1_TE);
+        tmp = PHYCR0_AUTO;
+    } else {
+        setPHYCR1(getPHYCR1() & ~PHYCR1_TE);
+        if (phyconf->mode == PHY_MODE_AUTONEGO) {
+            tmp = PHYCR0_AUTO;
+        } else {
+            tmp |= 0x04;
+            if (phyconf->speed  == PHY_SPEED_10) {
+                tmp |= 0x02;
+            }
+            if (phyconf->duplex == PHY_DUPLEX_HALF) {
+                tmp |= 0x01;
+            }
+        }
+    }
+    setPHYCR0(tmp);
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    uint16_t tmp = wiz_mdio_read(PHYRAR_BMCR);
+    if (phyconf->mode == PHY_MODE_TE) {
+        setPHYCR1(getPHYCR1() | PHYCR1_TE);
+        setPHYCR0(PHYCR0_AUTO);
+    } else {
+        setPHYCR1(getPHYCR1() & ~PHYCR1_TE);
+        if (phyconf->mode == PHY_MODE_AUTONEGO) {
+            tmp |= BMCR_ANE;
+        } else {
+            tmp &= ~(BMCR_ANE | BMCR_DPX | BMCR_SPD);
+            if (phyconf->duplex == PHY_DUPLEX_FULL) {
+                tmp |= BMCR_DPX;
+            }
+            if (phyconf->speed == PHY_SPEED_100) {
+                tmp |= BMCR_SPD;
+            }
+        }
+        wiz_mdio_write(PHYRAR_BMCR, tmp);
+    }
+#endif
+}
+
+void wizphy_getphyconf(wiz_PhyConf* phyconf) {
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    uint8_t tmp = 0;
+    tmp = getPHYSR();
+    if (getPHYCR1() & PHYCR1_TE) {
+        phyconf->mode = PHY_MODE_TE;
+    } else {
+        phyconf->mode = (tmp & (1 << 5)) ? PHY_MODE_MANUAL : PHY_MODE_AUTONEGO ;
+    }
+    phyconf->speed  = (tmp & (1 << 4)) ? PHY_SPEED_10    : PHY_SPEED_100;
+    phyconf->duplex = (tmp & (1 << 3)) ? PHY_DUPLEX_HALF : PHY_DUPLEX_FULL;
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    uint16_t tmp = 0;
+    tmp = wiz_mdio_read(PHYRAR_BMCR);
+    if (getPHYCR1() & PHYCR1_TE) {
+        phyconf->mode = PHY_MODE_TE;
+    } else {
+        phyconf->mode   = (tmp & BMCR_ANE) ? PHY_MODE_AUTONEGO : PHY_MODE_MANUAL;
+    }
+    phyconf->duplex = (tmp & BMCR_DPX) ? PHY_DUPLEX_FULL   : PHY_DUPLEX_HALF;
+    phyconf->speed  = (tmp & BMCR_SPD) ? PHY_SPEED_100     : PHY_SPEED_10;
+#endif
+}
+
+void wizphy_getphystat(wiz_PhyConf* phyconf) {
+    uint8_t tmp = 0;
+    tmp = getPHYSR();
+    if (getPHYCR1() & PHYCR1_TE) {
+        phyconf->mode = PHY_MODE_TE;
+    } else {
+        phyconf->mode   = (tmp & (1 << 5))    ? PHY_MODE_MANUAL : PHY_MODE_AUTONEGO ;
+    }
+    phyconf->speed  = (tmp & PHYSR_SPD) ? PHY_SPEED_10    : PHY_SPEED_100;
+    phyconf->duplex = (tmp & PHYSR_DPX) ? PHY_DUPLEX_HALF : PHY_DUPLEX_FULL;
+}
+
+void wizphy_setphypmode(uint8_t pmode) {
+#if (_PHY_IO_MODE_ == _PHY_IO_MODE_PHYCR_)
+    uint8_t tmp = getPHYCR1();
+    if (pmode == PHY_POWER_DOWN) {
+        tmp |= PHYCR1_PWDN;
+    } else {
+        tmp &= ~PHYCR1_PWDN;
+    }
+    setPHYCR1(tmp);
+#elif (_PHY_IO_MODE_ == _PHY_IO_MODE_MII_)
+    uint16_t tmp = 0;
+    tmp = wiz_mdio_read(PHYRAR_BMCR);
+    if (pmode == PHY_POWER_DOWN) {
+        tmp |= BMCR_PWDN;
+    } else {
+        tmp &= ~BMCR_PWDN;
+    }
+    wiz_mdio_write(PHYRAR_BMCR, tmp);
+#endif
+}
+
+int8_t wizchip_arp(wiz_ARP* arp) {
+    uint8_t tmp;
+    if (arp->destinfo.len == 16) {
+        setSLDIP6R(arp->destinfo.ip);
+        setSLCR(SLCR_ARP6);
+    } else {
+        setSLDIP4R(arp->destinfo.ip);
+        setSLCR(SLCR_ARP4);
+    }
+    while (getSLCR());
+    while ((tmp = getSLIR()) == 0x00);
+    setSLIRCLR(~SLIR_RA);
+    if (tmp & (SLIR_ARP4 | SLIR_ARP6)) {
+        getSLDHAR(arp->dha);
+        return 0;
+    }
+    return -1;
+}
+
+int8_t wizchip_ping(wiz_PING* ping) {
+    uint8_t tmp;
+    setPINGIDR(ping->id);
+    setPINGSEQR(ping->seq);
+    if (ping->destinfo.len == 16) {
+        setSLDIP6R(ping->destinfo.ip);
+        setSLCR(SLCR_PING6);
+    } else {
+        setSLDIP4R(ping->destinfo.ip);
+        setSLCR(SLCR_PING4);
+    }
+    while (getSLCR());
+    while ((tmp = getSLIR()) == 0x00);
+    setSLIRCLR(~SLIR_RA);
+    if (tmp & (SLIR_PING4 | SLIR_PING6)) {
+        return 0;
+    }
+    return -1;
+}
+
+int8_t wizchip_dad(uint8_t* ipv6) {
+    uint8_t tmp;
+    setSLDIP6R(ipv6);
+    setSLCR(SLCR_NS);
+    while (getSLCR());
+    while ((tmp = getSLIR()) == 0x00);
+    setSLIRCLR(~SLIR_RA);
+    if (tmp & SLIR_TOUT) {
+        return 0;
+    }
+    return -1;
+}
+
+int8_t wizchip_slaac(wiz_Prefix* prefix) {
+    uint8_t tmp;
+    setSLCR(SLCR_RS);
+    while (getSLCR());
+    while ((tmp = getSLIR()) == 0x00);
+    setSLIRCLR(~SLIR_RA);
+    if (tmp & SLIR_RS) {
+        prefix->len = getPLR();
+        prefix->flag = getPFR();
+        prefix->valid_lifetime = getVLTR();
+        prefix->preferred_lifetime = getPLTR();
+        getPAR(prefix->prefix);
+        return 0;
+    }
+    return -1;
+}
+
+int8_t wizchip_unsolicited(void) {
+    uint8_t tmp;
+    setSLCR(SLCR_UNA);
+    while (getSLCR());
+    while ((tmp = getSLIR()) == 0x00);
+    setSLIRCLR(~SLIR_RA);
+    if (tmp & SLIR_TOUT) {
+        return 0;
+    }
+    return -1;
+}
+
+int8_t wizchip_getprefix(wiz_Prefix * prefix) {
+    if (getSLIR() & SLIR_RA) {
+        prefix->len = getPLR();
+        prefix->flag = getPFR();
+        prefix->valid_lifetime = getVLTR();
+        prefix->preferred_lifetime = getPLTR();
+        getPAR(prefix->prefix);
+        setSLIRCLR(SLIR_RA);
+    }
+    return -1;
+}
+
+
+#endif
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+void wizchip_setnetinfo(wiz_NetInfo* pnetinfo) {
+    setSHAR(pnetinfo->mac);
+    setGAR(pnetinfo->gw);
+    setSUBR(pnetinfo->sn);
+    setSIPR(pnetinfo->ip);
+    _DNS_[0] = pnetinfo->dns[0];
+    _DNS_[1] = pnetinfo->dns[1];
+    _DNS_[2] = pnetinfo->dns[2];
+    _DNS_[3] = pnetinfo->dns[3];
+    _DHCP_   = pnetinfo->dhcp;
+}
+
+void wizchip_getnetinfo(wiz_NetInfo* pnetinfo) {
+    getSHAR(pnetinfo->mac);
+    getGAR(pnetinfo->gw);
+    getSUBR(pnetinfo->sn);
+    getSIPR(pnetinfo->ip);
+    pnetinfo->dns[0] = _DNS_[0];
+    pnetinfo->dns[1] = _DNS_[1];
+    pnetinfo->dns[2] = _DNS_[2];
+    pnetinfo->dns[3] = _DNS_[3];
+    pnetinfo->dhcp  = _DHCP_;
+}
+
+int8_t wizchip_setnetmode(netmode_type netmode) {
+    uint8_t tmp = 0;
+#if _WIZCHIP_ != W5500
+    if (netmode & ~(NM_WAKEONLAN | NM_PPPOE | NM_PINGBLOCK)) {
+        return -1;
+    }
+#else
+    if (netmode & ~(NM_WAKEONLAN | NM_PPPOE | NM_PINGBLOCK | NM_FORCEARP)) {
+        return -1;
+    }
+#endif
+    tmp = getMR();
+    tmp |= (uint8_t)netmode;
+    setMR(tmp);
+    return 0;
+}
+
+netmode_type wizchip_getnetmode(void) {
+    return (netmode_type) getMR();
+}
+
+void wizchip_settimeout(wiz_NetTimeout* nettime) {
+    setRCR(nettime->retry_cnt);
+    setRTR(nettime->time_100us);
+}
+
+void wizchip_gettimeout(wiz_NetTimeout* nettime) {
+    nettime->retry_cnt = getRCR();
+    nettime->time_100us = getRTR();
+}
+//teddy 240122
+#elif ((_WIZCHIP_ == 6100) ||(_WIZCHIP_ == 6300))
+void wizchip_setnetinfo(wiz_NetInfo* pnetinfo) {
+    uint8_t i = 0;
+    setSHAR(pnetinfo->mac);
+    setGAR(pnetinfo->gw);
+    setSUBR(pnetinfo->sn);
+    setSIPR(pnetinfo->ip);
+    setGA6R(pnetinfo->gw6);
+    setSUB6R(pnetinfo->sn6);
+    setLLAR(pnetinfo->lla);
+    setGUAR(pnetinfo->gua);
+
+    for (i = 0; i < 4; i++) {
+        _DNS_[i]  = pnetinfo->dns[i];
+    }
+    for (i = 0; i < 16; i++) {
+        _DNS6_[i] = pnetinfo->dns6[i];
+    }
+
+    _IPMODE_   = pnetinfo->ipmode;
+}
+
+void wizchip_getnetinfo(wiz_NetInfo* pnetinfo) {
+    uint8_t i = 0;
+    getSHAR(pnetinfo->mac);
+
+    getGAR(pnetinfo->gw);
+    getSUBR(pnetinfo->sn);
+    getSIPR(pnetinfo->ip);
+
+    getGA6R(pnetinfo->gw6);
+    getSUB6R(pnetinfo->sn6);
+    getLLAR(pnetinfo->lla);
+    getGUAR(pnetinfo->gua);
+    for (i = 0; i < 4; i++) {
+        pnetinfo->dns[i] = _DNS_[i];
+    }
+    for (i = 0; i < 16; i++) {
+        pnetinfo->dns6[i]  = _DNS6_[i];
+    }
+
+    pnetinfo->ipmode = _IPMODE_;
+}
+
+void wizchip_setnetmode(netmode_type netmode) {
+    uint32_t tmp = (uint32_t) netmode;
+    setNETMR((uint8_t)tmp);
+    setNETMR2((uint8_t)(tmp >> 8));
+    setNET4MR((uint8_t)(tmp >> 16));
+    setNET6MR((uint8_t)(tmp >> 24));
+}
+
+netmode_type wizchip_getnetmode(void) {
+    uint32_t ret = 0;
+    ret = getNETMR();
+    ret = (ret << 8)  + getNETMR2();
+    ret = (ret << 16) + getNET4MR();
+    ret = (ret << 24) + getNET6MR();
+    return (netmode_type)ret;
+}
+
+// netmode_type wizchip_getnetmode(void)
+// {
+//    return (netmode_type) getMR();
+// }
+
+void wizchip_settimeout(wiz_NetTimeout* nettime) {
+    setRCR(nettime->s_retry_cnt);
+    setRTR(nettime->s_time_100us);
+    setSLRCR(nettime->sl_retry_cnt);
+    setSLRTR(nettime->sl_time_100us);
+}
+
+void wizchip_gettimeout(wiz_NetTimeout* nettime) {
+    nettime->s_retry_cnt   = getRCR();
+    nettime->s_time_100us  = getRTR();
+    nettime->sl_retry_cnt  = getSLRCR();
+    nettime->sl_time_100us = getSLRTR();
+}
+#endif
+

--- a/third_party/ioLibrary_Driver/Ethernet/wizchip_conf.h
+++ b/third_party/ioLibrary_Driver/Ethernet/wizchip_conf.h
@@ -1,0 +1,1348 @@
+//*****************************************************************************
+//
+//! \file wizchip_conf.h
+//! \brief WIZCHIP Config Header File.
+//! \version 1.0.0
+//! \date 2013/10/21
+//! \par  Revision history
+//!       <2015/02/05> Notice
+//!        The version history is not updated after this point.
+//!        Download the latest version directly from GitHub. Please visit the our GitHub repository for ioLibrary.
+//!        >> https://github.com/Wiznet/ioLibrary_Driver
+//!       <2013/10/21> 1st Release
+//! \author MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+
+/**
+    @defgroup extra_functions 2. WIZnet Extra Functions
+
+    @brief These functions is optional function. It could be replaced at WIZCHIP I/O function because they were made by WIZCHIP I/O functions.
+    @details There are functions of configuring WIZCHIP, network, interrupt, phy, network information and timer. \n
+
+*/
+
+#ifndef  _WIZCHIP_CONF_H_
+#define  _WIZCHIP_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+/**
+    @brief Select WIZCHIP.
+    @todo You should select one, \b W5100, \b W5100S, \b W5200, \b W5300, \b W5500 or etc. \n\n
+         ex> <code> #define \_WIZCHIP_      W5500 </code>
+*/
+
+#define W5100						5100
+#define W5100S						5100+5
+#define W5200						5200
+#define W5300						5300
+#define W5500						5500
+#define W6100						6100
+#define W6300                 6300
+
+
+#ifndef _WIZCHIP_
+// NOTE_LIHAN: Some sections of this code are not yet fully defined.
+#define _WIZCHIP_                      W6300   // W5100, W5100S, W5200, W5300, W5500, 6300
+#endif
+
+//
+//#ifndef _WIZCHIP_
+//   #error  please Define your WIZnet chip numer
+//#endif
+
+
+#define _WIZCHIP_IO_MODE_NONE_         0x0000
+#define _WIZCHIP_IO_MODE_BUS_          0x0100 /**< Bus interface mode */
+#define _WIZCHIP_IO_MODE_SPI_          0x0200 /**< SPI interface mode */
+//#define _WIZCHIP_IO_MODE_IIC_          0x0400
+//#define _WIZCHIP_IO_MODE_SDIO_         0x0800
+// Add to
+//
+
+#define _WIZCHIP_IO_MODE_BUS_DIR_      (_WIZCHIP_IO_MODE_BUS_ + 1) /**< BUS interface mode for direct  */
+#define _WIZCHIP_IO_MODE_BUS_INDIR_    (_WIZCHIP_IO_MODE_BUS_ + 2) /**< BUS interface mode for indirect */
+
+#define _WIZCHIP_IO_MODE_SPI_VDM_      (_WIZCHIP_IO_MODE_SPI_ + 1) /**< SPI interface mode for variable length data*/
+#define _WIZCHIP_IO_MODE_SPI_FDM_      (_WIZCHIP_IO_MODE_SPI_ + 2) /**< SPI interface mode for fixed length data mode*/
+#define _WIZCHIP_IO_MODE_SPI_5500_     (_WIZCHIP_IO_MODE_SPI_ + 3) /**< SPI interface mode for fixed length data mode*/
+//teddy 240122
+#define _WIZCHIP_IO_MODE_SPI_QSPI_     (_WIZCHIP_IO_MODE_SPI_ + 4) /**< SPI interface mode for QSPI mode*/
+
+
+
+/**
+    @brief PHY can be accessed by @ref _PHYCR0_, _PHYCR1_.
+    @details It provides hardware access method.
+    @note It is smaller s/w footprint than @ref _PHY_IO_MODE_MII_.
+    @sa _PHY_IO_MODE_MII_, _PHY_IO_MODE_
+    @sa ctlwizchip(), getPHYCR0(), getPHYCR1(), setPHYCR1(), getPHYSR()
+*/
+#define _PHY_IO_MODE_PHYCR_            0x0000
+
+/**
+    @brief PHY can be accessed by MDC/MDIO signals of MII interface.
+    @details It provide software access method.
+    @note It is bigger s/w footprint than @ref _PHY_IO_MODE_PHYCR_.
+    @sa _PHY_IO_MODE_PHYCR_, _PHY_IO_MODE_
+    @sa ctlwizchip(), wiz_read_mdio(), wiz_write_mdio()
+*/
+#define _PHY_IO_MODE_MII_              0x0010
+
+/**
+    @brief Select PHY Access Mode
+    @details @ref _PHY_IO_MODE_ selects PHY access method.
+    @todo You should select one of @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_.
+    @sa ctlwizchip()
+*/
+#define _PHY_IO_MODE_                  _PHY_IO_MODE_MII_ //_PHY_IO_MODE_MII_
+
+
+
+#if   (_WIZCHIP_ == W5100)
+#define _WIZCHIP_ID_                "W5100\0"
+/**
+    @brief Define interface mode.
+    @todo you should select interface mode as chip. Select one of @ref \_WIZCHIP_IO_MODE_SPI_ , @ref \_WIZCHIP_IO_MODE_BUS_DIR_ or @ref \_WIZCHIP_IO_MODE_BUS_INDIR_
+*/
+// 	#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_DIR_
+//	#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_INDIR_
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_
+
+//A20150601 : Define the unit of IO DATA.
+typedef   uint8_t   iodata_t;
+//A20150401 : Indclude W5100.h file
+#include "W5100/w5100.h"
+
+#elif (_WIZCHIP_ == W5100S)
+#define _WIZCHIP_ID_                "W5100S\0"
+/**
+    @brief Define interface mode.
+    @todo you should select interface mode as chip. Select one of @ref \_WIZCHIP_IO_MODE_SPI_ , @ref \_WIZCHIP_IO_MODE_BUS_DIR_ or @ref \_WIZCHIP_IO_MODE_BUS_INDIR_
+*/
+#if 0
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_INDIR_
+#elif 0
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_5500_
+#else
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_
+#endif
+
+//A20150601 : Define the unit of IO DATA.
+typedef   uint8_t   iodata_t;
+//A20150401 : Indclude W5100.h file
+#include "W5100S/w5100s.h"
+#elif (_WIZCHIP_ == W5200)
+#define _WIZCHIP_ID_                "W5200\0"
+/**
+    @brief Define interface mode.
+    @todo you should select interface mode as chip. Select one of @ref \_WIZCHIP_IO_MODE_SPI_ or @ref \	_WIZCHIP_IO_MODE_BUS_INDIR_
+*/
+#ifndef _WIZCHIP_IO_MODE_
+// #define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_INDIR_
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_
+#endif
+//A20150601 : Define the unit of IO DATA.
+typedef   uint8_t   iodata_t;
+#include "W5200/w5200.h"
+#elif (_WIZCHIP_ == W5500)
+#define _WIZCHIP_ID_                 "W5500\0"
+
+/**
+    @brief Define interface mode. \n
+    @todo Should select interface mode as chip.
+          - @ref \_WIZCHIP_IO_MODE_SPI_ \n
+            -@ref \_WIZCHIP_IO_MODE_SPI_VDM_ : Valid only in @ref \_WIZCHIP_ == W5500 \n
+            -@ref \_WIZCHIP_IO_MODE_SPI_FDM_ : Valid only in @ref \_WIZCHIP_ == W5500 \n
+          - @ref \_WIZCHIP_IO_MODE_BUS_ \n
+            - @ref \_WIZCHIP_IO_MODE_BUS_DIR_ \n
+            - @ref \_WIZCHIP_IO_MODE_BUS_INDIR_ \n
+          - Others will be defined in future. \n\n
+          ex> <code> #define \_WIZCHIP_IO_MODE_ \_WIZCHIP_IO_MODE_SPI_VDM_ </code>
+
+*/
+#ifndef _WIZCHIP_IO_MODE_
+//#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_FDM_
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_
+#endif
+//A20150601 : Define the unit of IO DATA.
+typedef   uint8_t   iodata_t;
+#include "W5500/w5500.h"
+#elif ( _WIZCHIP_ == W5300)
+#define _WIZCHIP_ID_                 "W5300\0"
+/**
+    @brief Define interface mode.
+    @todo you should select interface mode as chip. Select one of @ref \_WIZCHIP_IO_MODE_SPI_ , @ref \_WIZCHIP_IO_MODE_BUS_DIR_ or @ref \_WIZCHIP_IO_MODE_BUS_INDIR_
+*/
+#ifndef _WIZCHIP_IO_MODE_
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_DIR_
+// #define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_INDIR_
+#endif
+
+//A20150601 : Define the unit and bus width of IO DATA.
+/**
+    @brief Select the data width 8 or 16 bits.
+    @todo you should select the bus width. Select one of 8 or 16.
+*/
+#ifndef _WIZCHIP_IO_BUS_WIDTH_
+#define _WIZCHIP_IO_BUS_WIDTH_       16  // 8
+#endif
+#if _WIZCHIP_IO_BUS_WIDTH_ == 8
+typedef   uint8_t   iodata_t;
+#elif _WIZCHIP_IO_BUS_WIDTH_ == 16
+typedef   uint16_t   iodata_t;
+#else
+#error "Unknown _WIZCHIP_IO_BUS_WIDTH_. It should be 8 or 16."
+#endif
+//
+#include "W5300/w5300.h"
+
+
+#elif ( _WIZCHIP_ == W6100)
+
+#define _WIZCHIP_ID_                "W6100\0"
+
+/**
+    @brief Define @ref _WIZCHIP_ interface mode.
+    @todo You should select interface mode of @ref _WIZCHIP_.\n\n
+        Select one of @ref _WIZCHIP_IO_MODE_SPI_VDM_, @ref _WIZCHIP_IO_MODE_SPI_FDM_, and @ref _WIZCHIP_IO_MODE_BUS_INDIR_
+    @sa WIZCHIP_READ(), WIZCHIP_WRITE(), WIZCHIP_READ_BUF(), WIZCHIP_WRITE_BUF()
+*/
+#if 1
+// 20231103 taylor
+#define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_SPI_VDM_
+#elif 0
+#define _WIZCHIP_IO_MODE_         _WIZCHIP_IO_MODE_SPI_VDM_
+#else
+#define _WIZCHIP_IO_MODE_         _WIZCHIP_IO_MODE_SPV_FDM_
+#endif
+
+typedef   uint8_t   iodata_t;       ///< IO access unit. bus width
+typedef   int16_t   datasize_t;     ///< sent or received data size
+#include "./W6100/w6100.h"
+#include "../Application/Application.h"
+
+//teddy 240122
+#elif ( _WIZCHIP_ == W6300)
+
+#define _WIZCHIP_ID_                "W6300\0"
+
+
+
+
+/**
+    @brief Define @ref _WIZCHIP_ interface mode.
+    @todo You should select interface mode of @ref _WIZCHIP_.\n\n
+        Select one of @ref _WIZCHIP_IO_MODE_SPI_QSPI_, @ref _WIZCHIP_IO_MODE_SPI_VDM_,@ref _WIZCHIP_IO_MODE_BUS_INDIR_
+    @sa WIZCHIP_READ(), WIZCHIP_WRITE(), WIZCHIP_READ_BUF(), WIZCHIP_WRITE_BUF()
+*/
+
+#define QSPI_SINGLE_MODE            (0x00 << 6) // 0b0000 0000 // 0x00
+#define QSPI_DUAL_MODE              (0x01 << 6) // 0b0100 0000 // 0x40
+#define QSPI_QUAD_MODE              (0x02 << 6) // 0b1000 0000 // 0x80 
+
+#ifndef _WIZCHIP_QSPI_MODE_
+#define _WIZCHIP_QSPI_MODE_          QSPI_SINGLE_MODE
+#endif
+
+//#define _WIZCHIP_IO_MODE_         _WIZCHIP_IO_MODE_BUS_INDIR_
+#define _WIZCHIP_IO_MODE_           ((_WIZCHIP_IO_MODE_SPI_ & 0xff00) | (_WIZCHIP_QSPI_MODE_ & 0x00ff))
+
+
+
+typedef   uint8_t   iodata_t;       ///< IO access unit. bus width
+typedef   int16_t   datasize_t;     ///< sent or received data size
+#include "./W6300/w6300.h"
+#include "../Application/Application.h"
+
+#else
+#error "Unknown defined _WIZCHIP_. You should define one of 5100, 5200, 5300, 5500, 6100 and 6300!!!"
+#endif
+
+#ifndef _WIZCHIP_IO_MODE_
+#error "Undefined _WIZCHIP_IO_MODE_. You should define it !!!"
+#endif
+
+/**
+    @brief Define I/O base address when BUS IF mode.
+    @todo Should re-define it to fit your system when BUS IF Mode (@ref \_WIZCHIP_IO_MODE_BUS_,
+         @ref \_WIZCHIP_IO_MODE_BUS_DIR_, @ref \_WIZCHIP_IO_MODE_BUS_INDIR_). \n\n
+         ex> <code> #define \_WIZCHIP_IO_BASE_      0x00008000 </code>
+*/
+#if _WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_BUS_
+#if 1
+// 20231108 taylor
+#if (_WIZCHIP_ == W6300)
+#define _WIZCHIP_IO_BASE_            0x60000000   // for W6100-EVB
+#elif (_WIZCHIP_ == W6100)
+#define _WIZCHIP_IO_BASE_            0x60000000   // for W5100S-EV
+#elif (_WIZCHIP_ == W5100S)
+#define _WIZCHIP_IO_BASE_            0x60000000   // for W5100S-EVB
+#elif (_WIZCHIP_ == W5300)
+#define _WIZCHIP_IO_BASE_            0x68000000   // for W5300 by javakys 20210408 @66c27e960a813f7ea6e8b1ce083d12b3e7e86fc0
+#else
+#define _WIZCHIP_IO_BASE_            0x00000000
+#endif
+
+#else
+#if (_WIZCHIP_ == W6100)
+#define _WIZCHIP_IO_BASE_            0x60000000   // for W6100 BUS
+#else
+//	#define _WIZCHIP_IO_BASE_				0x60000000	// for 5100S IND
+#define _WIZCHIP_IO_BASE_				0x68000000	// for W5300
+#endif
+#endif
+#elif _WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_SPI_
+//#define _WIZCHIP_IO_BASE_				0x00000000	// for 5100S SPI
+#endif
+
+#ifndef _WIZCHIP_IO_BASE_
+#if 1
+// 20231108 taylor
+#define _WIZCHIP_IO_BASE_              0x00000000
+#else
+#define _WIZCHIP_IO_BASE_              0x00000000  // 0x8000
+#endif
+#endif
+
+//M20150401 : Typing Error
+//#if _WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_BUS
+#if _WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_BUS_
+#ifndef _WIZCHIP_IO_BASE_
+#error "You should be define _WIZCHIP_IO_BASE to fit your system memory map."
+#endif
+#endif
+
+#if _WIZCHIP_ >= W5200
+#define _WIZCHIP_SOCK_NUM_   8   ///< The count of independant socket of @b WIZCHIP
+#else
+#define _WIZCHIP_SOCK_NUM_   4   ///< The count of independant socket of @b WIZCHIP
+#endif
+
+
+/********************************************************
+    WIZCHIP BASIC IF functions for SPI, SDIO, I2C , ETC.
+*********************************************************/
+/**
+    @ingroup DATA_TYPE
+    @brief The set of callback functions for W5500:@ref WIZCHIP_IO_Functions W5200:@ref WIZCHIP_IO_Functions_W5200
+*/
+typedef struct __WIZCHIP {
+    uint16_t  if_mode;               ///< host interface mode
+    uint8_t   id[8];                 ///< @b WIZCHIP ID such as @b 5100, @b 5100S, @b 5200, @b 5500, and so on.
+    /**
+        The set of critical section callback func.
+    */
+    struct _CRIS {
+        void (*_enter)  (void);       ///< crtical section enter
+        void (*_exit) (void);         ///< critial section exit
+    } CRIS;
+    /**
+        The set of @ref \_WIZCHIP_ select control callback func.
+    */
+    struct _CS {
+        void (*_select)  (void);      ///< @ref \_WIZCHIP_ selected
+        void (*_deselect)(void);      ///< @ref \_WIZCHIP_ deselected
+    } CS;
+    /**
+        The set of interface IO callback func.
+    */
+    union _IF {
+        /**
+            For BUS interface IO
+        */
+        //M20156501 : Modify the function name for integrating with W5300
+        //struct
+        //{
+        //   uint8_t  (*_read_byte)  (uint32_t AddrSel);
+        //   void     (*_write_byte) (uint32_t AddrSel, uint8_t wb);
+        //}BUS;
+        struct {
+            iodata_t  (*_read_data)   (uint32_t AddrSel);
+            void      (*_write_data)  (uint32_t AddrSel, iodata_t wb);
+#if 1
+            // 20231103 taylor
+            void      (*_read_data_buf)  (uint32_t AddrSel, iodata_t* pBuf, int16_t len, uint8_t addrinc);  ///< Read @ref iodata_t as many as <i>len</i> from @ref _WIZCHIP_ through BUS
+            void      (*_write_data_buf) (uint32_t AddrSel, iodata_t* pBuf, int16_t len, uint8_t addrinc);  ///< Write @ref iodata_t data as many as <i>len</i> to @ref _WIZCHIP_ through BUS
+#endif
+        } BUS;
+
+        /**
+            For SPI interface IO
+        */
+        struct {
+            uint8_t (*_read_byte)   (void);
+            void    (*_write_byte)  (uint8_t wb);
+            void    (*_read_burst)  (uint8_t* pBuf, uint16_t len);
+            void    (*_write_burst) (uint8_t* pBuf, uint16_t len);
+        } SPI;
+
+        /**
+            For QSPI interface IO
+        */
+        //teddy 240122
+        struct {
+            void    (*_read_qspi)  (uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len);
+            void    (*_write_qspi) (uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len);
+        } QSPI;
+        // To be added
+        //
+    } IF;
+} _WIZCHIP;
+
+extern _WIZCHIP  WIZCHIP;
+
+/**
+    @ingroup DATA_TYPE
+    WIZCHIP control type enumration used in @ref ctlwizchip().
+*/
+typedef enum {
+    CW_SYS_LOCK,           ///< Lock or Unlock @ref _WIZCHIP_ with @ref SYS_CHIP_LOCK, @ref SYS_PHY_LOCK, and @ref SYS_NET_LOCK
+    CW_SYS_UNLOCK,         ///< Lock or Unlock @ref _WIZCHIP_ with @ref SYS_CHIP_LOCK, @ref SYS_PHY_LOCK, and @ref SYS_NET_LOCK
+    CW_GET_SYSLOCK,        ///< Get the lock status of @ref _WIZCHIP_ with @ref SYS_CHIP_LOCK, @ref SYS_PHY_LOCK, and @ref SYS_NET_LOCK
+
+    CW_RESET_WIZCHIP,      ///< Reset @ref _WIZCHIP_ by software
+    CW_INIT_WIZCHIP,       ///< Initialize to SOCKETn buffer size with n byte array typed uint8_t
+    CW_GET_INTERRUPT,      ///< Get the interrupt status with @ref intr_kind
+    CW_CLR_INTERRUPT,      ///< Clear the interrupt with @ref intr_kind
+    CW_SET_INTRMASK,       ///< Set the interrupt mask with @ref intr_kind
+    CW_GET_INTRMASK,       ///< Get the interrupt mask with @ref intr_kind
+    CW_SET_INTRTIME,       ///< Set the interrupt pending time
+    CW_GET_INTRTIME,       ///< Get the interrupt pending time
+    CW_SET_IEN,            ///< Set the global interrupt enable only when @ref SYS_CHIP_LOCK is not set
+    CW_GET_IEN,            ///< Get the global interrupt enable
+
+    CW_GET_ID,             ///< Get @ref _WIZCHIP_ name.
+    CW_GET_VER,            ///< Get the version of TCP/IP TOE engine
+
+    CW_SET_SYSCLK,         ///< Set the system clock with @ref SYSCLK_100MHZ or SYSCLK_10MHZ only when @ref SYS_CHIP_LOCK is unlock
+    CW_GET_SYSCLK,         ///< Get the system clock with @ref SYSCLK_100MHZ or SYSCLK_10MHZ
+
+    CW_RESET_PHY,          ///< Reset PHY
+    CW_SET_PHYCONF,        ///< Set PHY operation mode (Manual/Auto, 10/100, Half/Full) with @ref wiz_PhyConf
+    CW_GET_PHYCONF,        ///< Get PHY operation mode (Manual/Auto, 10/100, Half/Full) with @ref wiz_PhyConf
+    CW_GET_PHYSTATUS,      ///< Get real operation mode with @ref wiz_PhyConf when PHY is linked up.
+    CW_SET_PHYPOWMODE,     ///< Set PHY power mode with @ref PHY_POWER_NORM or PHY_POWER_DOWN
+    CW_GET_PHYPOWMODE,     ///< Get PHY Power mode with @ref PHY_POWER_NORM or PHY_POWER_DOWN
+    CW_GET_PHYLINK         ///< Get PHY Link status with @ref PHY_LINK_ON or @ref PHY_LINK_OFF
+} ctlwizchip_type;
+
+/**
+    @ingroup DATA_TYPE
+    Network control type enumration used in @ref ctlnetwork().
+*/
+typedef enum {
+    CN_SET_NETINFO,  ///< Set Network with @ref wiz_NetInfo
+    CN_GET_NETINFO,  ///< Get Network with @ref wiz_NetInfo
+    CN_SET_NETMODE,  ///< Set network mode as WOL, PPPoE, Ping Block, and Force ARP mode
+    CN_GET_NETMODE,  ///< Get network mode as WOL, PPPoE, Ping Block, and Force ARP mode
+    CN_SET_TIMEOUT,  ///< Set network timeout as retry count and time.
+    CN_GET_TIMEOUT,  ///< Get network timeout as retry count and time.
+    //teddy 240122
+#if ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+    CN_SET_PREFER,   ///< Set the preferred source IPv6 address of @ref _SLCR_.\n Refer to @ref IPV6_ADDR_AUTO, @ref IPV6_ADDR_LLA, @ref IPV6_ADDR_GUA
+    CN_GET_PREFER,   ///< Get the preferred source IPv6 address of @ref _SLCR_.\n Refer to @ref IPV6_ADDR_AUTO, @ref IPV6_ADDR_LLA, @ref IPV6_ADDR_GUA
+#endif
+} ctlnetwork_type;
+
+//teddy 240122
+#if ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup DATA_TYPE
+    @brief  Network Service Control Type enumeration
+    @details @ref ctlnetservice_type includes network management or monitor functions for @ref _WIZCHIP_.
+    @sa ctlnetservice(), wiz_IPAddress, wiz_Prefix
+*/
+typedef enum {
+    CNS_ARP,            ///< ARP process with @ref wiz_IPAddress
+    CNS_PING,           ///< PING process with @ref wiz_IPAddress
+    CNS_DAD,            ///< Duplicated IPv6 Address Detection
+    /**
+        @brief Stateless Address Auto-configuration(SLAAC) with @ref wiz_Prefix.
+        @details @ref CNS_SLAAC sends first RS message to all-router and then receives RA message from a router.
+        @note It is valid only when the first received RA option is the source link-layer address(0x01) and the second is prefix information(0x03).\n
+             Refer to @ref SLIR_RS.
+        @sa ctlnetservice()
+        @sa CNS_GET_PREFIX
+    */
+    CNS_SLAAC,
+    CNS_UNSOL_NA,       ///< Unsolicited Neighbor Advertisement for update @ref _WIZCHIP_ network information to neighbors
+    /**
+        @brief Get prefix information with @ref wiz_Prefix.
+        @details @ref CNS_GET_PREFIX can get prefix information of RA message to be sent by a router without RS message.
+        @note It is valid only when @ref IK_SOCKL_RA is set and the prefix information(0x03) of RA option is first received.
+        @sa ctlnetservice()
+        @sa CNS_SLAAC
+    */
+    CNS_GET_PREFIX
+} ctlnetservice_type;
+#endif
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+/**
+    @ingroup DATA_TYPE
+    Interrupt kind when CW_SET_INTRRUPT, CW_GET_INTERRUPT, CW_SET_INTRMASK
+    and CW_GET_INTRMASK is used in @ref ctlnetwork().
+    It can be used with OR operation.
+*/
+typedef enum {
+#if   _WIZCHIP_ == W5500
+    IK_WOL               = (1 << 4),   ///< Wake On Lan by receiving the magic packet. Valid in W500.
+#elif _WIZCHIP_ == W5300
+    IK_FMTU              = (1 << 4),   ///< Received a ICMP message (Fragment MTU)
+#endif
+
+    IK_PPPOE_TERMINATED  = (1 << 5),   ///< PPPoE Disconnected
+
+#if _WIZCHIP_ != W5200
+    IK_DEST_UNREACH      = (1 << 6),   ///< Destination IP & Port Unreachable, No use in W5200
+#endif
+
+    IK_IP_CONFLICT       = (1 << 7),   ///< IP conflict occurred
+
+    IK_SOCK_0            = (1 << 8),   ///< Socket 0 interrupt
+    IK_SOCK_1            = (1 << 9),   ///< Socket 1 interrupt
+    IK_SOCK_2            = (1 << 10),  ///< Socket 2 interrupt
+    IK_SOCK_3            = (1 << 11),  ///< Socket 3 interrupt
+#if _WIZCHIP_ > W5100S
+    IK_SOCK_4            = (1 << 12),  ///< Socket 4 interrupt, No use in 5100
+    IK_SOCK_5            = (1 << 13),  ///< Socket 5 interrupt, No use in 5100
+    IK_SOCK_6            = (1 << 14),  ///< Socket 6 interrupt, No use in 5100
+    IK_SOCK_7            = (1 << 15),  ///< Socket 7 interrupt, No use in 5100
+#endif
+
+#if _WIZCHIP_ > W5100S
+    IK_SOCK_ALL          = (0xFF << 8) ///< All Socket interrupt
+#else
+    IK_SOCK_ALL          = (0x0F << 8) ///< All Socket interrupt
+#endif
+} intr_kind;
+//teddy 240122
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup DATA_TYPE
+    @brief Interrupt Kind
+    @details @ref intr_kind can be used as the interrupt bits of @ref _IR_, @ref _SIR_, and @ref _SLIR_,\n
+            It can be used as the interrupt mask bits of @ref _IMR_, @ref _SIMR_, and @ref _SLIMR_,\n
+            and also, It can be used as the interrupt clear bits of @ref _IRCLR_, @ref _Sn_IRCLR_, and @ref _SLIRCLR_.
+    @note It can be used with @b OR operation.
+    @sa ctlwizchip(), CW_GET_INTERRUPT, CW_CLR_INTERRUPT, CW_GET_INTRMASK, CW_SET_INTRMASK
+    @sa ctlnetservice(), ctlnetservice_type
+    @sa wizchip_getinterrupt(), wizchip_clrinterrupt(), wizchip_getinterruptmask(), wizchip_setinterruptmask()
+*/
+typedef enum {
+    IK_PPPOE_TERMINATED = (1 << 0),     ///< PPPoE Termination Interrupt
+    IK_DEST_UNREACH     = (1 << 1),     ///< ICMPv4 Destination Unreachable Interrupt
+    IK_IP_CONFLICT      = (1 << 2),     ///< IPv4 Address Conflict Interrupt
+    IK_DEST_UNREACH6    = (1 << 4),     ///< ICMPv6 Destination Unreachable Interrupt
+    IK_WOL              = (1 << 7),     ///< WOL magic packet Interrupt
+    IK_NET_ALL          = (0x97),       ///< All Network Interrupt
+
+    IK_SOCK_0           = (1 << 8),     ///< Socket 0 Interrupt
+    IK_SOCK_1           = (1 << 9),     ///< Socket 1 Interrupt
+    IK_SOCK_2           = (1 << 10),    ///< Socket 2 Interrupt
+    IK_SOCK_3           = (1 << 11),    ///< Socket 3 Interrupt
+    IK_SOCK_4           = (1 << 12),    ///< Socket 4 Interrupt
+    IK_SOCK_5           = (1 << 13),    ///< Socket 5 Interrupt
+    IK_SOCK_6           = (1 << 14),    ///< Socket 6 Interrupt
+    IK_SOCK_7           = (1 << 15),    ///< Socket 7 Interrupt
+    IK_SOCK_ALL         = (0xFF << 8),  ///< All Socket Interrupt
+
+    IK_SOCKL_TOUT       = (1 << 16),    ///< @ref _SLCR_ Timeout Interrupt.\n Refer to @ref ctlnetservice_type.
+    IK_SOCKL_ARP4       = (1 << 17),    ///< @ref _SLCR_ APR4 Interrupt.\n Refer to @ref CNS_ARP.
+    IK_SOCKL_PING4      = (1 << 18),    ///< @ref _SLCR_ PING4 Interrupt.\n Refer to @ref CNS_PING.
+    IK_SOCKL_ARP6       = (1 << 19),    ///< @ref _SLCR_ ARP6 Interrupt.\n Refer to @ref CNS_ARP.
+    IK_SOCKL_PING6      = (1 << 20),    ///< @ref _SLCR_ PING6 Interrupt.\n Refer to @ref CNS_PING.
+    IK_SOCKL_NS         = (1 << 21),    ///< @ref _SLCR_ NS Interrupt.\n Refer to @ref CNS_DAD.
+    IK_SOCKL_RS         = (1 << 22),    ///< @ref _SLCR_ RS Interrupt.\n Refer to @ref CNS_SLAAC.
+    IK_SOCKL_RA         = (1 << 23),    ///< @ref _SLCR_ RA Interrupt.\n Refer to @ref CNS_GET_PREFIX.
+    IK_SOCKL_ALL        = (0xFF << 16), ///< @ref _SLCR_ All Interrupt
+
+    IK_INT_ALL          = (0x00FFFF97)   ///< All Interrupt
+} intr_kind;
+#endif
+
+//teddy 240122
+#if ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+#define SYS_CHIP_LOCK           (1<<2)   ///< CHIP LOCK. \n Refer to @ref CW_SYS_LOCK, @ref CW_SYS_UNLOCK, and @ref CW_GET_SYSLOCK.
+#define SYS_NET_LOCK            (1<<1)   ///< NETWORK Information LOCK. \n Refer to @ref CW_SYS_LOCK, @ref CW_SYS_UNLOCK, and @ref CW_GET_SYSLOCK.
+#define SYS_PHY_LOCK            (1<<0)   ///< PHY LOCK.\n Refer to @ref CW_SYS_LOCK, @ref CW_SYS_UNLOCK, and @ref CW_GET_SYSLOCK.
+
+#define SYSCLK_100MHZ            0       ///< System Clock 100MHz.\n Refer to Refer to @ref CW_SET_SYSCLK and  @ref CW_GET_SYSCLK.
+#define SYSCLK_25MHZ             1       ///< System Clock 25MHz.\n Refer to Refer to @ref CW_SET_SYSCLK and  @ref CW_GET_SYSCLK.
+
+#define PHY_MODE_MANUAL          0       ///< Configured PHY operation mode with user setting.\n Refer to @ref CW_SET_PHYCONF and @ref CW_GET_PHYCONF.
+#define PHY_MODE_AUTONEGO        1       ///< Configured PHY operation mode with auto-negotiation.\n Refer to @ref CW_SET_PHYCONF and @ref CW_GET_PHYCONF.
+#define PHY_MODE_TE              2
+
+#define IPV6_ADDR_AUTO           0x00    ///< IPv6 Address Type : Auto.\n Refer to @ref CN_SET_PREFER, @ref CN_GET_PREFER.
+#define IPV6_ADDR_LLA            0x02    ///< IPv6 Address Type : LLA. \n Refer to @ref CN_SET_PREFER, @ref CN_GET_PREFER, @ref CNS_DAD.
+#define IPV6_ADDR_GUA            0x03    ///< IPv6 Address Type : GUA. \n Refer to @ref CN_SET_PREFER, @ref CN_GET_PREFER, @ref CNS_DAD.
+#endif
+
+#define PHY_CONFBY_HW            0     ///< Configured PHY operation mode by HW pin
+#define PHY_CONFBY_SW            1     ///< Configured PHY operation mode by SW register   
+#define PHY_MODE_MANUAL          0     ///< Configured PHY operation mode with user setting.
+#define PHY_MODE_AUTONEGO        1     ///< Configured PHY operation mode with auto-negotiation
+#define PHY_SPEED_10             0     ///< Link Speed 10
+#define PHY_SPEED_100            1     ///< Link Speed 100
+#define PHY_DUPLEX_HALF          0     ///< Link Half-Duplex
+#define PHY_DUPLEX_FULL          1     ///< Link Full-Duplex
+#define PHY_LINK_OFF             0     ///< Link Off
+#define PHY_LINK_ON              1     ///< Link On
+#define PHY_POWER_NORM           0     ///< PHY power normal mode
+#define PHY_POWER_DOWN           1     ///< PHY power down mode 
+
+
+//teddy 240122
+#if _WIZCHIP_ == W5100S || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
+/**
+    @ingroup DATA_TYPE
+    It configures PHY configuration when CW_SET PHYCONF or CW_GET_PHYCONF in W5500,
+    and it indicates the real PHY status configured by HW or SW in all WIZCHIP. \n
+    Valid only in W5500.
+*/
+typedef struct wiz_PhyConf_t {
+    uint8_t by;       ///< set by @ref PHY_CONFBY_HW or @ref PHY_CONFBY_SW
+    uint8_t mode;     ///< set by @ref PHY_MODE_MANUAL or @ref PHY_MODE_AUTONEGO
+    uint8_t speed;    ///< set by @ref PHY_SPEED_10 or @ref PHY_SPEED_100
+    uint8_t duplex;   ///< set by @ref PHY_DUPLEX_HALF @ref PHY_DUPLEX_FULL
+    //uint8_t power;  ///< set by @ref PHY_POWER_NORM or @ref PHY_POWER_DOWN
+    //uint8_t link;   ///< Valid only in CW_GET_PHYSTATUS. set by @ref PHY_LINK_ON or PHY_DUPLEX_OFF
+} wiz_PhyConf;
+#endif
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+/**
+    @ingroup DATA_TYPE
+    It used in setting dhcp_mode of @ref wiz_NetInfo.
+*/
+typedef enum {
+    NETINFO_STATIC = 1,    ///< Static IP configuration by manually.
+    NETINFO_DHCP           ///< Dynamic IP configruation from a DHCP sever
+} dhcp_mode;
+
+/**
+    @ingroup DATA_TYPE
+    Network Information for WIZCHIP
+*/
+typedef struct wiz_NetInfo_t {
+    uint8_t mac[6];  ///< Source Mac Address
+    uint8_t ip[4];   ///< Source IP Address
+    uint8_t sn[4];   ///< Subnet Mask
+    uint8_t gw[4];   ///< Gateway IP Address
+    uint8_t dns[4];  ///< DNS server IP Address
+    dhcp_mode dhcp;  ///< 1 - Static, 2 - DHCP
+} wiz_NetInfo;
+
+/**
+    @ingroup DATA_TYPE
+    Network mode
+*/
+typedef enum {
+#if _WIZCHIP_ == W5500
+    NM_FORCEARP    = (1 << 1), ///< Force to APP send whenever udp data is sent. Valid only in W5500
+#endif
+    NM_WAKEONLAN   = (1 << 5), ///< Wake On Lan
+    NM_PINGBLOCK   = (1 << 4), ///< Block ping-request
+    NM_PPPOE       = (1 << 3), ///< PPPoE mode
+} netmode_type;
+
+/**
+    @ingroup DATA_TYPE
+    Used in CN_SET_TIMEOUT or CN_GET_TIMEOUT of @ref ctlwizchip() for timeout configruation.
+*/
+typedef struct wiz_NetTimeout_t {
+    uint8_t  retry_cnt;     ///< retry count
+    uint16_t time_100us;    ///< time unit 100us
+} wiz_NetTimeout;
+//teddy 240122
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup DATA_TYPE
+    @brief IP Address Configuration Mode
+    @details @ref ipconf_mode can be used to save the DHCP mode running on your system.
+    @sa ctlnetwork(), CN_SET_NETINFO, CN_GET_NETINFO
+    @sa wizchip_setnetinfo(), wizchip_getnetinfo(), wiz_NetInfo
+*/
+typedef enum {
+    NETINFO_NONE       = 0x00,    ///< No use DHCP
+    NETINFO_STATIC_V4  = 0x01,    ///< Static IPv4 configuration by manually.
+    NETINFO_STATIC_V6  = 0x02,    ///< Static IPv6 configuration by manually.
+    NETINFO_STATIC_ALL = 0x03,    ///< Static IPv4 and IPv6 configuration by manually.
+    NETINFO_SLAAC_V6   = 0x04,    ///< Stateless Adders Auto Configuration for IPv6
+    NETINFO_DHCP_V4    = 0x10,    ///< Dynamic IPv4 configuration from a DHCP sever
+    NETINFO_DHCP_V6    = 0x20,    ///< Dynamic IPv6 configuration from a DHCP sever
+    NETINFO_DHCP_ALL   = 0x30     ///< Dynamic IPv4 and IPv6 configuration from a DHCP sever
+} ipconf_mode;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Network Information for @ref _WIZCHIP_
+    @details @ref wiz_NetInfo is a structure type to configure or indicate the network information of @ref _WIZCHIP_.
+    @sa ctlnetwork(), CN_SET_NETINFO, CN_GET_NETINFO
+    @sa wizchip_setnetinfo(), wizchip_getnetinfo()
+*/
+
+typedef enum {
+    NETINFO_STATIC = 1,    ///< Static IP configuration by manually.
+    NETINFO_DHCP           ///< Dynamic IP configruation from a DHCP sever
+} dhcp_mode;
+
+typedef struct wiz_NetInfo_t {
+    uint8_t     mac[6];    ///< Source Hardware Address
+    uint8_t     ip[4];     ///< Source IPv4 Address
+    uint8_t     sn[4];     ///< Subnet Mask value
+    uint8_t     gw[4];     ///< Gateway IPv4 Address
+    uint8_t     lla[16];   ///< Source Link Local Address
+    uint8_t     gua[16];   ///< Source Global Unicast Address
+    uint8_t     sn6[16];   ///< IPv6 Prefix
+    uint8_t     gw6[16];   ///< Gateway IPv6 Address
+    uint8_t     dns[4];    ///< DNS server IPv4 Address
+    uint8_t     dns6[16];  ///< DNS server IPv6 Address
+    ipconf_mode ipmode;    ///< IP Configuration Mode
+    dhcp_mode dhcp;  ///< 1 - Static, 2 - DHCP
+} wiz_NetInfo;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Network mode Configuration
+    @details @ref netmode_type includes the network mode control function such as ping, TCP/RST block and etc.
+    @sa ctlnetwork(), CN_SET_NETMODE, CN_GET_NETMODE
+*/
+typedef enum {
+    // NETMR Bit Values
+    NM_IPB_V4            = (1 << 0),      ///< IPv4 Packet Block
+    NM_IPB_V6            = (1 << 1),      ///< IPv6 Packet Block
+    NM_WOL               = (1 << 2),      ///< Wake On Lan(WOL) Mode
+    NM_PB6_MULTI         = (1 << 4),      ///< PING6 request from multicasting group address Block
+    NM_PB6_ALLNODE       = (1 << 5),      ///< PING6 request from all-node multicasting address Block
+    NM_MR_MASK           = (0x37),        ///< @ref _NETMR_ Mask value
+
+    // NETMR2 Bit Values
+    NM_PPPoE             = (1 << 8),      ///< PPPoE Mode
+    NM_DHA_SELECT        = (1 << 15),     ///< Destination Hardware Address Select
+    NM_MR2_MASK          = (0x09 << 8),   ///< @ref _NETMR2_ Mask value
+
+    //NET4MR Bit Values
+    NM_PB4_ALL           = (1 << 16),     ///< All PING4 request Block
+    NM_TRSTB_V4          = (1 << 17),     ///< TCP RST packet for IPv4 Send Block
+    NM_PARP_V4           = (1 << 18),     ///< ARP request for IPv4 before PINGv4 Replay
+    NM_UNRB_V4           = (1 << 19),     ///< Unreachable Destination for IPv4 Block
+    NM_NET4_MASK         = (0x0F << 16),  ///< @ref _NET4MR_ Mask value
+
+    //NET4MR Bit Values
+    NM_PB6_ALL           = (1 << 24),     ///< All PING6 request Block
+    NM_TRSTB_V6          = (1 << 25),     ///< TCP RST packet for IPv6 Send Block
+    NM_PARP_V6           = (1 << 26),     ///< ARP request for IPv6 before PINGv4 Replay
+    NM_UNRB_V6           = (1 << 27),     ///< Unreachable Destination for IPv6 Block
+    NM_NET6_MASK         = (0x0F << 24),  ///< @ref _NET6MR_ Mask value
+
+    NM_MASK_ALL          = (0x0F0F0937)   ///< @ref netmode_type all mask value
+} netmode_type;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Network Timeout for @ref _WIZCHIP_
+    @details @ref wiz_NetInfo is a structure type to configure or indicate the network timeout of @ref _WIZCHIP_.
+    @sa ctlnetwork(), CN_SET_TIMEOUT, CN_GET_TIMEOUT
+    @sa wizchip_settimeout(), wizchip_gettimeout()
+*/
+typedef struct wiz_NetTimeout_t {
+    uint8_t  s_retry_cnt;         ///< The default retry count of SOCKETn
+    uint16_t s_time_100us;        ///< The retransmission time of SOCKETn (unit 100us)
+    uint8_t  sl_retry_cnt;        ///< The retry count of SOCKET-less
+    uint16_t sl_time_100us;       ///< The retransmission time of SOCKET-less (unit 100us)
+} wiz_NetTimeout;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Destination Information for Network Service of @ref _WIZCHIP_
+    @details @ref wiz_NetInfo is a structure type to configure or indicate a destination information of network service.
+    @sa ctlnetservice(), CNS_ARP, CNS_PING
+    @sa IK_SOCKL_TOUT, IK_SOCKL_ARP4, IK_SOCKL_ARP6, IK_SOCKL_PING4, IK_SOCKL_PING6
+*/
+typedef struct wiz_IPAddress_t {
+    uint8_t ip[16];               ///< Destination IP Address. \n IPv4 index : 0 to 3, IPv6 index : 0 to 15
+    uint8_t len;                  ///< Destination IP Address Length.\n IPv4 : 4, IPv6 : 16.
+} wiz_IPAddress;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Prefix Information
+    @details @ref wiz_Prefix is a structure type to indicate a prefix information(0x03) of received RA message from a router.
+    @sa ctlnetservice(), CNS_SLAAC, IK_SOCKL_RS
+    @sa IK_SOCKL_TOUT, IK_SOCKL_RA, CNS_GET_PREFIX
+*/
+typedef struct wiz_Prefix_t {
+    uint8_t  len;                 ///< Prefix Length. \n It is used to set @ref _SUB6R_ to 1 as many as <i>len</i> from LSB bit.
+    uint8_t  flag;                ///< Prefix Flag
+    uint32_t valid_lifetime;      ///< Valid Lifetime
+    uint32_t preferred_lifetime;  ///< Preferred Lifetime
+    uint8_t  prefix[16];          ///< Prefix
+} wiz_Prefix;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Destination Information & Destination Hardware Address for @ref CNS_ARP
+    @details @ref wiz_ARP is a structure type to set a destination IP address for ARP-request or \n
+            indicate a destination hardware address in APR-reply.
+    @sa ctlnetservice(), CNS_ARP
+    @sa IK_SOCKL_TOUT, IK_SOCKL_ARP4, IK_SOCKL_ARP6
+*/
+typedef struct wiz_ARP_t {
+    wiz_IPAddress destinfo;       ///< Destination IP address for ARP-request
+    uint8_t dha[6];               ///< Destination Hardware Address when ARP-reply is received from the destination.
+} wiz_ARP;
+
+/**
+    @ingroup DATA_TYPE
+    @brief Destination Information & Destination Hardware Address for @ref CNS_ARP
+    @details @ref wiz_PING is a structure type to set a ID, sequence number, destination IP address for PING-request.
+    @sa ctlnetservice(), CNS_PING
+    @sa IK_SOCKL_TOUT, IK_SOCKL_PING4, IK_SOCKL_PING6
+*/
+typedef struct wiz_PING_t {
+    uint16_t id;
+    uint16_t seq;
+    wiz_IPAddress destinfo;
+} wiz_PING;
+#endif
+
+/**
+    @brief Registers call back function for critical section of I/O functions such as
+    \ref WIZCHIP_READ, @ref WIZCHIP_WRITE, @ref WIZCHIP_READ_BUF and @ref WIZCHIP_WRITE_BUF.
+    @param cris_en : callback function for critical section enter.
+    @param cris_ex : callback function for critical section exit.
+    @todo Describe @ref WIZCHIP_CRITICAL_ENTER and @ref WIZCHIP_CRITICAL_EXIT marco or register your functions.
+    @note If you do not describe or register, default functions(@ref wizchip_cris_enter & @ref wizchip_cris_exit) is called.
+*/
+void reg_wizchip_cris_cbfunc(void(*cris_en)(void), void(*cris_ex)(void));
+
+
+/**
+    @brief Registers call back function for WIZCHIP select & deselect.
+    @param cs_sel : callback function for WIZCHIP select
+    @param cs_desel : callback fucntion for WIZCHIP deselect
+    @todo Describe @ref wizchip_cs_select and @ref wizchip_cs_deselect function or register your functions.
+    @note If you do not describe or register, null function is called.
+*/
+void reg_wizchip_cs_cbfunc(void(*cs_sel)(void), void(*cs_desel)(void));
+
+/**
+    @brief Registers call back function for bus interface.
+    @param bus_rb   : callback function to read byte data using system bus
+    @param bus_wb   : callback function to write byte data using system bus
+    @todo Describe @ref wizchip_bus_readbyte and @ref wizchip_bus_writebyte function
+    or register your functions.
+    @note If you do not describe or register, null function is called.
+*/
+//M20150601 : For integrating with W5300
+//void reg_wizchip_bus_cbfunc(uint8_t (*bus_rb)(uint32_t addr), void (*bus_wb)(uint32_t addr, uint8_t wb));
+void reg_wizchip_bus_cbfunc(iodata_t (*bus_rb)(uint32_t addr), void (*bus_wb)(uint32_t addr, iodata_t wb));
+
+/**
+    @brief Registers call back function for SPI interface.
+    @param spi_rb : callback function to read byte using SPI
+    @param spi_wb : callback function to write byte using SPI
+    @todo Describe \ref wizchip_spi_readbyte and \ref wizchip_spi_writebyte function
+    or register your functions.
+    @note If you do not describe or register, null function is called.
+*/
+#if _WIZCHIP_ == W6100
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void),
+                            void (*spi_wb)(uint8_t wb),
+                            void (*spi_rbuf)(uint8_t* buf, datasize_t len),
+                            void (*spi_wbuf)(uint8_t* buf, datasize_t len));
+#else
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), void (*spi_wb)(uint8_t wb));
+#endif
+
+/**
+    @brief Registers call back function for SPI interface.
+    @param spi_rb : callback function to burst read using SPI
+    @param spi_wb : callback function to burst write using SPI
+    @todo Describe \ref wizchip_spi_readbyte and \ref wizchip_spi_writebyte function
+    or register your functions.
+    @note If you do not describe or register, null function is called.
+*/
+void reg_wizchip_spiburst_cbfunc(void (*spi_rb)(uint8_t* pBuf, uint16_t len), void (*spi_wb)(uint8_t* pBuf, uint16_t len));
+
+//teddy 240122
+/**
+    @brief Registers call back function for QSPI interface.
+    @param spi_rb : callback function to read using QSPI
+    @param spi_wb : callback function to write using QSPI
+    @todo Describe \ref wizchip_qspi_read and \ref wizchip_qspi_write function
+    or register your functions.
+    @note If you do not describe or register, null function is called.
+*/
+void reg_wizchip_qspi_cbfunc(void (*qspi_rb)(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len), void (*qspi_wb)(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len));
+
+/**
+    @ingroup extra_functions
+    @brief Controls to the WIZCHIP.
+    @details Resets WIZCHIP & internal PHY, Configures PHY mode, Monitor PHY(Link,Speed,Half/Full/Auto),
+    controls interrupt & mask and so on.
+    @param cwtype : Decides to the control type
+    @param arg : arg type is dependent on cwtype.
+    @return  0 : Success \n
+           -1 : Fail because of invalid \ref ctlwizchip_type or unsupported \ref ctlwizchip_type in WIZCHIP
+*/
+int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg);
+
+/**
+    @ingroup extra_functions
+    @brief Controls to network.
+    @details Controls to network environment, mode, timeout and so on.
+    @param cntype : Input. Decides to the control type
+    @param arg : Inout. arg type is dependent on cntype.
+    @return -1 : Fail because of invalid \ref ctlnetwork_type or unsupported \ref ctlnetwork_type in WIZCHIP \n
+            0 : Success
+*/
+int8_t ctlnetwork(ctlnetwork_type cntype, void* arg);
+
+//teddy 240122
+#if ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup extra_functions
+    @brief Controls to network service.
+    @details Controls to network environment, mode, timeout and so on.
+    @param cnstype : Decides to the control type
+    @param arg : arg type is dependent on cnstype.
+    @return -1 : Fail because of invalid @ref ctlnetwork_type or unsupported @ref ctlnetwork_type \n
+            0 : Success
+*/
+int8_t ctlnetservice(ctlnetservice_type cnstype, void* arg);
+#endif
+
+/*
+    The following functions are implemented for internal use.
+    but You can call these functions for code size reduction instead of ctlwizchip() and ctlnetwork().
+*/
+
+/**
+    @ingroup extra_functions
+    @brief Reset WIZCHIP by softly.
+*/
+void   wizchip_sw_reset(void);
+
+/**
+    @ingroup extra_functions
+    @brief Initializes WIZCHIP with socket buffer size
+    @param txsize Socket tx buffer sizes. If null, initialized the default size 2KB.
+    @param rxsize Socket rx buffer sizes. If null, initialized the default size 2KB.
+    @return 0 : succcess \n
+          -1 : fail. Invalid buffer size
+*/
+int8_t wizchip_init(uint8_t* txsize, uint8_t* rxsize);
+
+/**
+    @ingroup extra_functions
+    @brief Clear Interrupt of WIZCHIP.
+    @param intr : @ref intr_kind value operated OR. It can type-cast to uint16_t.
+*/
+void wizchip_clrinterrupt(intr_kind intr);
+
+/**
+    @ingroup extra_functions
+    @brief Get Interrupt of WIZCHIP.
+    @return @ref intr_kind value operated OR. It can type-cast to uint16_t.
+*/
+intr_kind wizchip_getinterrupt(void);
+
+/**
+    @ingroup extra_functions
+    @brief Mask or Unmask Interrupt of WIZCHIP.
+    @param intr : @ref intr_kind value operated OR. It can type-cast to uint16_t.
+*/
+void wizchip_setinterruptmask(intr_kind intr);
+
+/**
+    @ingroup extra_functions
+    @brief Get Interrupt mask of WIZCHIP.
+    @return : The operated OR vaule of @ref intr_kind. It can type-cast to uint16_t.
+*/
+intr_kind wizchip_getinterruptmask(void);
+
+//todo
+#if _WIZCHIP_ > W5100
+int8_t wizphy_getphylink(void);              ///< get the link status of phy in WIZCHIP. No use in W5100
+int8_t wizphy_getphypmode(void);             ///< get the power mode of PHY in WIZCHIP. No use in W5100
+#endif
+
+#if _WIZCHIP_ == W5100S || _WIZCHIP_ == W5500
+void   wizphy_reset(void);                   ///< Reset phy. Vailid only in W5500
+/**
+    @ingroup extra_functions
+    @brief Set the phy information for WIZCHIP without power mode
+    @param phyconf : @ref wiz_PhyConf
+*/
+void   wizphy_setphyconf(wiz_PhyConf* phyconf);
+/**
+    @ingroup extra_functions
+    @brief Get phy configuration information.
+    @param phyconf : @ref wiz_PhyConf
+*/
+void   wizphy_getphyconf(wiz_PhyConf* phyconf);
+/**
+    @ingroup extra_functions
+    @brief Get phy status.
+    @param phyconf : @ref wiz_PhyConf
+*/
+void   wizphy_getphystat(wiz_PhyConf* phyconf);
+/**
+    @ingroup extra_functions
+    @brief set the power mode of phy inside WIZCHIP. Refer to @ref PHYCFGR in W5500, @ref PHYSTATUS in W5200
+    @param pmode Settig value of power down mode.
+*/
+int8_t wizphy_setphypmode(uint8_t pmode);
+//teddy 240122
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup extra_functions
+    @brief Reset the integrated PHY.
+    @details @ref wizphy_reset() resets the integrated Ethernet PHY \n
+            through @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_. \n
+    @note In @ref _PHY_IO_MODE_PHYCR_, It needs a stable reset time. \n
+         So you need to wait for the stable reset time.\n
+         The stable reset time for each @ref _WIZCHIP_ maybe different.
+    @sa ctlwizchip(), CW_RESET_PHY
+    @sa _PHY_IO_MODE_
+*/
+void wizphy_reset(void);                   ///< Reset phy. Vailid only in W5500
+
+/**
+    @ingroup extra_functions
+    @details @ref wizphy_setphyconf() set a operation mode of the integrated Ethernet PHY \n
+            through @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_.\n
+    @param phyconf : @ref wiz_PhyConf
+    @note The operation mode can be applied to Ethernet PHY after the Ethernet PHY is reset by @ref wizphy_reset().
+    @sa ctlwizchip(), CW_SET_PHYCONF, CW_GET_PHYCONF, CW_GET_PHYSTATUS, CW_RESET_PHY
+    @sa _PHY_IO_MODE_, wizphy_getphyconf(), wizphy_getphystatus(), wizphy_reset()
+*/
+void wizphy_setphyconf(wiz_PhyConf* phyconf);
+
+/**
+    @ingroup extra_functions
+    @brief Get the integrated Ethernet PHY operation mode.
+    @details @ref wizphy_getphyconf() gets a operation mode of the integrated Ethernet PHY \n
+            through @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_.\n
+    @param phyconf : @ref wiz_PhyConf
+    @note It gets just the configured value for PHY operation, not real PHY operation.\n
+         To get real PHY operation, you can call @ref wizphy_getphystatus()
+    @sa ctlwizchip(), CW_GET_PHYCONF, CW_SET_PHYCONF, CW_GET_PHYSTATUS
+    @sa _PHY_IO_MODE_, wizphy_setphyconf(), wizphy_getphystatus()
+*/
+void wizphy_getphyconf(wiz_PhyConf* phyconf);
+
+/**
+    @ingroup extra_functions
+    @brief Get the real PHY operation status when link is established.
+    @details @ref wizphy_getphystatus() gets a operation mode of the integrated Ethernet PHY. \n
+    @param phyconf : @ref wiz_PhyConf
+    @sa ctlwizchip(), CW_GET_PHYSTATUS, CW_GET_PHYCONF, CW_SET_PHYCONF
+    @sa wizphy_setphyconf(), wizphy_getphyconf()
+*/
+void wizphy_getphystat(wiz_PhyConf* phyconf);
+
+/**
+    @ingroup extra_functions
+    @brief Set the power mode of integrated Ethernet PHY.
+    @details @ref wizphy_setphypmode() sets a power mode of the integrated Ethernet PHY \n
+            through @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_.\n
+    @param pmode @ref PHY_POWER_NORM or @ref PHY_POWER_DOWN
+    @note When the integrated Ethernet PHY enters in power down mode, \n
+         the system clock of @ref _WIZCHIP_ is changed to the lowest speed. \n
+         So, you should adjust the access time of @ref _WIZCHIP_ to the changed system clock.
+    @sa ctlwizchip(), CW_SET_PHYPOWMODE, CW_GET_PHYPOWMODE
+    @sa _PHY_IO_MODE_, wizphy_setphypmode(), wizphy_getphypmode()
+*/
+void wizphy_setphypmode(uint8_t pmode);
+
+/**
+    @ingroup extra_functions
+    @brief get the power mode of integrated Ethernet PHY.
+    @details @ref wizphy_getphypmode() gets a power mode of the integrated Ethernet PHY \n
+            through @ref _PHY_IO_MODE_PHYCR_ or @ref _PHY_IO_MODE_MII_.\n
+    @return @ref PHY_POWER_NORM or @ref PHY_POWER_DOWN
+    @note When the integrated Ethernet PHY enters in power down mode,\n
+         the system clock of @ref _WIZCHIP_ is changed to the lowest speed. \n
+         So, you should adjust the access time of @ref _WIZCHIP_ to the changed system clock.
+    @sa ctlwizchip(), CW_SET_PHYPOWMODE, CW_GET_PHYPOWMODE
+    @sa _PHY_IO_MODE_, wizphy_setphypmode(), wizphy_getphypmode()
+*/
+int8_t wizphy_getphypmode(void);
+
+/**
+    @ingroup extra_functions
+    @brief Set the network information for @ref _WIZCHIP_
+    @param pnetinfo : @ref wiz_NetInfo
+    @sa ctlnetwork(), CN_SET_NETINFO, CN_GET_NETINFO
+    @sa wizchip_getnetinfo()
+*/
+void wizchip_setnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network information of @ref _WIZCHIP_
+    @param pnetinfo : @ref wiz_NetInfo
+    @sa ctlnetwork(), CN_GET_NETINFO, CN_SET_NETINFO
+    @sa wizchip_setnetinfo()
+*/
+void wizchip_getnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Set the network mode such as WOL, PPPoE, PING Block, and etc.
+    @param netmode : @ref netmode_type.
+    @sa ctlnetwork(), CN_SET_NETMODE, CN_GET_NETMODE
+    @sa wizchip_getnetmode()
+*/
+void wizchip_setnetmode(netmode_type netmode);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network mode such as WOL, PPPoE, PING Block, and etc.
+    @return @ref netmode_type.
+    @sa ctlnetwork(), CN_GET_NETMODE, CN_SET_NETMODE
+    @sa wizchip_setnetmode()
+*/
+netmode_type wizchip_getnetmode(void);
+
+/**
+    @ingroup extra_functions
+    @brief Set retransmission time values and retry counts.
+    @param nettime : @ref wiz_NetTimeout.
+    @sa ctlnetwork(), CN_SET_TIMEOUT, CN_GET_TIMEOUT
+    @sa wizchip_gettimeout()
+*/
+void wizchip_settimeout(wiz_NetTimeout* nettime);
+
+/**
+    @ingroup extra_functions
+    @brief Get retransmission time values and retry counts.
+    @param nettime : @ref wiz_NetTimeout.
+    @sa ctlnetwork(), CN_GET_TIMEOUT, CN_SET_TIMEOUT
+    @sa wizchip_settimeout()
+*/
+void wizchip_gettimeout(wiz_NetTimeout* nettime);
+
+/**
+    @ingroup extra_functions
+    @brief ARP process.
+    @details @ref wizchip_arp() processes ARP. \n
+            It sends the APR-request to destination and waits to receive the ARP-reply.
+    @param arp @ref wiz_ARP.\n
+              It sets a destination IP address and indicates the destination hardware address.
+    @return 0 : success, destination hardware address is valid.\n
+           -1 : fail. destination hardware address is invalid because timeout is occurred.\n
+    @sa ctlnetservice(), CNS_ARP
+*/
+int8_t wizchip_arp(wiz_ARP* arp);
+
+/**
+    @ingroup extra_functions
+    @brief PING process.
+    @details @ref wizchip_ping() processes PING. \n
+            It sends the PING-request to destination and waits to receive the PING-reply.
+    @param ping @ref wiz_PING, It sets a destination IP address, ID, SEQ of PING-request message
+    @return 0 : success, PING-reply is successfully received.\n
+           -1 : fail. Timeout is occurred.\n
+    @sa ctlnetservice(), CNS_PING
+*/
+int8_t wizchip_ping(wiz_PING* ping);
+
+/**
+    @ingroup extra_functions
+    @brief DAD(Duplcated Address Detection) process.
+    @details @ref wizchip_dad() detects the duplication of source IPv6 address.\n
+            It sends a NA message for DAD to all-node multicasting address(FF02::01).
+    @param ipv6 : IPv6 address to be detected the duplication.
+    @return 0 : success, There is no duplicated address. \n
+           -1 : fail. @ref _WIZCHIP_ source IP address to use is duplicated with a neighbor's one.
+    @sa ctlnetservice(), CNS_DAD
+*/
+int8_t wizchip_dad(uint8_t* ipv6);
+
+/**
+    @ingroup extra_functions
+    @brief Stateless Address Auto Configuration(SLAAC) process.
+    @details @ref wizchip_slaac() get a prefix information from a router for SLAAC.\n
+            It sends first a RS message to all-router and waits to receive a RS message with prefix information option from a router.
+    @param prefix @ref wiz_Prefix
+    @return 0 : success, RA message is successfully received, and <i>prefix</i> is valid.  \n
+           -1 : fail. Timeout is occurred.
+    @note It is valid only when the prefix information type(0x03) of RA option received first.\n
+         The prefix option should be in the order of prefix length, prefix flag, valid lifetime, default lifetime and prefix address. \n
+         For more detail, Refer to @ref SLIR_RS.
+    @sa ctlnetservice(), CNS_SLAAC
+*/
+int8_t wizchip_slaac(wiz_Prefix* prefix);
+
+/**
+    @ingroup extra_functions
+    @brief Unsolicited NA process.
+    @details @ref wizchip_unsolicited() updates the network information of @ref _WIZCHIP_ to neighbors.\n
+            It sends a unsolicited NA message with @ref _LLAR_ or @ref _GUAR_ to neighbors \n
+            in order to update the network information of @ref _WIZCHIP_.\n
+            Because the unsolicited NA message have no reply, timeout is always occurred.
+    @return always 0. Timeout is occurred.
+    @sa ctlnetservice(), CNS_UNSOL
+*/
+int8_t wizchip_unsolicited(void);
+
+/**
+    @ingroup extra_functions
+    @brief Get a prefix information of RA message from a router.
+    @details @ref wizchip_getprefix() get a prefix information of RA is periodically sent by a router. \n
+    @return 0 : success, a RS message is successfully received from a router.
+           -1 : fail, a RS message is not received from a router yet.
+    @note It is valid only when the prefix information type(0x03) of RA option received first.\n
+         The prefix option should be in the order of prefix length, prefix flag, valid lifetime, default lifetime and prefix address. \n
+         For more detail, Refer to @ref SLIR_RS.
+    @sa ctlnetservice(), CNS_GET_PREFIX
+*/
+int8_t wizchip_getprefix(wiz_Prefix * prefix);
+#endif
+
+#if (_WIZCHIP_ == W5100 || _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5300 || _WIZCHIP_ == W5500)
+/**
+    @ingroup extra_functions
+    @brief Set the network information for WIZCHIP
+    @param pnetinfo : @ref wizNetInfo
+*/
+void wizchip_setnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network information for WIZCHIP
+    @param pnetinfo : @ref wizNetInfo
+*/
+void wizchip_getnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Set the network mode such WOL, PPPoE, Ping Block, and etc.
+    @param pnetinfo Value of network mode. Refer to @ref netmode_type.
+*/
+int8_t wizchip_setnetmode(netmode_type netmode);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network mode such WOL, PPPoE, Ping Block, and etc.
+    @return Value of network mode. Refer to @ref netmode_type.
+*/
+netmode_type wizchip_getnetmode(void);
+
+/**
+    @ingroup extra_functions
+    @brief Set retry time value(@ref _RTR_) and retry count(@ref _RCR_).
+    @details @ref _RTR_ configures the retransmission timeout period and @ref _RCR_ configures the number of time of retransmission.
+    @param nettime @ref _RTR_ value and @ref _RCR_ value. Refer to @ref wiz_NetTimeout.
+*/
+void wizchip_settimeout(wiz_NetTimeout* nettime);
+
+/**
+    @ingroup extra_functions
+    @brief Get retry time value(@ref _RTR_) and retry count(@ref _RCR_).
+    @details @ref _RTR_ configures the retransmission timeout period and @ref _RCR_ configures the number of time of retransmission.
+    @param nettime @ref _RTR_ value and @ref _RCR_ value. Refer to @ref wiz_NetTimeout.
+*/
+void wizchip_gettimeout(wiz_NetTimeout* nettime);
+//teddy 240122
+#elif ((_WIZCHIP_ == W6100)||(_WIZCHIP_ == W6300))
+/**
+    @ingroup extra_functions
+    @brief Set the network information for @ref _WIZCHIP_
+    @param pnetinfo : @ref wiz_NetInfo
+    @sa ctlnetwork(), CN_SET_NETINFO, CN_GET_NETINFO
+    @sa wizchip_getnetinfo()
+*/
+void wizchip_setnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network information of @ref _WIZCHIP_
+    @param pnetinfo : @ref wiz_NetInfo
+    @sa ctlnetwork(), CN_GET_NETINFO, CN_SET_NETINFO
+    @sa wizchip_setnetinfo()
+*/
+void wizchip_getnetinfo(wiz_NetInfo* pnetinfo);
+
+/**
+    @ingroup extra_functions
+    @brief Set the network mode such as WOL, PPPoE, PING Block, and etc.
+    @param netmode : @ref netmode_type.
+    @sa ctlnetwork(), CN_SET_NETMODE, CN_GET_NETMODE
+    @sa wizchip_getnetmode()
+*/
+void wizchip_setnetmode(netmode_type netmode);
+
+/**
+    @ingroup extra_functions
+    @brief Get the network mode such as WOL, PPPoE, PING Block, and etc.
+    @return @ref netmode_type.
+    @sa ctlnetwork(), CN_GET_NETMODE, CN_SET_NETMODE
+    @sa wizchip_setnetmode()
+*/
+netmode_type wizchip_getnetmode(void);
+
+/**
+    @ingroup extra_functions
+    @brief Set retransmission time values and retry counts.
+    @param nettime : @ref wiz_NetTimeout.
+    @sa ctlnetwork(), CN_SET_TIMEOUT, CN_GET_TIMEOUT
+    @sa wizchip_gettimeout()
+*/
+void wizchip_settimeout(wiz_NetTimeout* nettime);
+
+/**
+    @ingroup extra_functions
+    @brief Get retransmission time values and retry counts.
+    @param nettime : @ref wiz_NetTimeout.
+    @sa ctlnetwork(), CN_GET_TIMEOUT, CN_SET_TIMEOUT
+    @sa wizchip_settimeout()
+*/
+void wizchip_gettimeout(wiz_NetTimeout* nettime);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif   // _WIZCHIP_CONF_H_

--- a/third_party/ioLibrary_Driver/Internet/DHCP/dhcp.c
+++ b/third_party/ioLibrary_Driver/Internet/DHCP/dhcp.c
@@ -1,0 +1,1118 @@
+//*****************************************************************************
+//
+//! \file dhcp.c
+//! \brief DHCP APIs implement file.
+//! \details Processing DHCP protocol as DISCOVER, OFFER, REQUEST, ACK, NACK and DECLINE.
+//! \version 1.1.1
+//! \date 2019/10/08
+//! \par  Revision history
+//!       <2019/10/08> compare DHCP server ip address
+//!       <2013/11/18> 1st Release
+//!       <2012/12/20> V1.1.0
+//!         1. Optimize code
+//!         2. Add reg_dhcp_cbfunc()
+//!         3. Add DHCP_stop()
+//!         4. Integrate check_DHCP_state() & DHCP_run() to DHCP_run()
+//!         5. Don't care system endian
+//!         6. Add comments
+//!       <2012/12/26> V1.1.1
+//!         1. Modify variable declaration: dhcp_tick_1s is declared volatile for code optimization
+//! \author Eric Jung & MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+
+#include "socket.h"
+#include "dhcp.h"
+
+/* If you want to display debug & processing message, Define _DHCP_DEBUG_ in dhcp.h */
+
+#ifdef _DHCP_DEBUG_
+#include <stdio.h>
+#endif
+
+/* DHCP state machine. */
+#define STATE_DHCP_INIT          0        ///< Initialize
+#define STATE_DHCP_DISCOVER      1        ///< send DISCOVER and wait OFFER
+#define STATE_DHCP_REQUEST       2        ///< send REQEUST and wait ACK or NACK
+#define STATE_DHCP_LEASED        3        ///< ReceiveD ACK and IP leased
+#define STATE_DHCP_REREQUEST     4        ///< send REQUEST for maintaining leased IP
+#define STATE_DHCP_RELEASE       5        ///< No use
+#define STATE_DHCP_STOP          6        ///< Stop processing DHCP
+
+#define DHCP_FLAGSBROADCAST      0x8000   ///< The broadcast value of flags in @ref RIP_MSG 
+#define DHCP_FLAGSUNICAST        0x0000   ///< The unicast   value of flags in @ref RIP_MSG
+
+/* DHCP message OP code */
+#define DHCP_BOOTREQUEST         1        ///< Request Message used in op of @ref RIP_MSG
+#define DHCP_BOOTREPLY           2        ///< Reply Message used i op of @ref RIP_MSG
+
+/* DHCP message type */
+#define DHCP_DISCOVER            1        ///< DISCOVER message in OPT of @ref RIP_MSG
+#define DHCP_OFFER               2        ///< OFFER message in OPT of @ref RIP_MSG
+#define DHCP_REQUEST             3        ///< REQUEST message in OPT of @ref RIP_MSG
+#define DHCP_DECLINE             4        ///< DECLINE message in OPT of @ref RIP_MSG
+#define DHCP_ACK                 5        ///< ACK message in OPT of @ref RIP_MSG
+#define DHCP_NAK                 6        ///< NACK message in OPT of @ref RIP_MSG
+#define DHCP_RELEASE             7        ///< RELEASE message in OPT of @ref RIP_MSG. No use
+#define DHCP_INFORM              8        ///< INFORM message in OPT of @ref RIP_MSG. No use
+
+#define DHCP_HTYPE10MB           1        ///< Used in type of @ref RIP_MSG
+#define DHCP_HTYPE100MB          2        ///< Used in type of @ref RIP_MSG
+
+#define DHCP_HLENETHERNET        6        ///< Used in hlen of @ref RIP_MSG
+#define DHCP_HOPS                0        ///< Used in hops of @ref RIP_MSG
+#define DHCP_SECS                0        ///< Used in secs of @ref RIP_MSG
+
+#define INFINITE_LEASETIME       0xffffffff	///< Infinite lease time
+
+#define OPT_SIZE                 312               /// Max OPT size of @ref RIP_MSG
+#define RIP_MSG_SIZE             (236+OPT_SIZE)    /// Max size of @ref RIP_MSG
+
+/*
+    @brief DHCP option and value (cf. RFC1533)
+*/
+enum {
+    padOption               = 0,
+    subnetMask              = 1,
+    timerOffset             = 2,
+    routersOnSubnet         = 3,
+    timeServer              = 4,
+    nameServer              = 5,
+    dns                     = 6,
+    logServer               = 7,
+    cookieServer            = 8,
+    lprServer               = 9,
+    impressServer           = 10,
+    resourceLocationServer	= 11,
+    hostName                = 12,
+    bootFileSize            = 13,
+    meritDumpFile           = 14,
+    domainName              = 15,
+    swapServer              = 16,
+    rootPath                = 17,
+    extentionsPath          = 18,
+    IPforwarding            = 19,
+    nonLocalSourceRouting   = 20,
+    policyFilter            = 21,
+    maxDgramReasmSize       = 22,
+    defaultIPTTL            = 23,
+    pathMTUagingTimeout     = 24,
+    pathMTUplateauTable     = 25,
+    ifMTU                   = 26,
+    allSubnetsLocal         = 27,
+    broadcastAddr           = 28,
+    performMaskDiscovery    = 29,
+    maskSupplier            = 30,
+    performRouterDiscovery  = 31,
+    routerSolicitationAddr  = 32,
+    staticRoute             = 33,
+    trailerEncapsulation    = 34,
+    arpCacheTimeout         = 35,
+    ethernetEncapsulation   = 36,
+    tcpDefaultTTL           = 37,
+    tcpKeepaliveInterval    = 38,
+    tcpKeepaliveGarbage     = 39,
+    nisDomainName           = 40,
+    nisServers              = 41,
+    ntpServers              = 42,
+    vendorSpecificInfo      = 43,
+    netBIOSnameServer       = 44,
+    netBIOSdgramDistServer	= 45,
+    netBIOSnodeType         = 46,
+    netBIOSscope            = 47,
+    xFontServer             = 48,
+    xDisplayManager         = 49,
+    dhcpRequestedIPaddr     = 50,
+    dhcpIPaddrLeaseTime     = 51,
+    dhcpOptionOverload      = 52,
+    dhcpMessageType         = 53,
+    dhcpServerIdentifier    = 54,
+    dhcpParamRequest        = 55,
+    dhcpMsg                 = 56,
+    dhcpMaxMsgSize          = 57,
+    dhcpT1value             = 58,
+    dhcpT2value             = 59,
+    dhcpClassIdentifier     = 60,
+    dhcpClientIdentifier    = 61,
+    endOption               = 255
+};
+
+/*
+    @brief DHCP message format
+*/
+typedef struct {
+    uint8_t  op;            ///< @ref DHCP_BOOTREQUEST or @ref DHCP_BOOTREPLY
+    uint8_t  htype;         ///< @ref DHCP_HTYPE10MB or @ref DHCP_HTYPE100MB
+    uint8_t  hlen;          ///< @ref DHCP_HLENETHERNET
+    uint8_t  hops;          ///< @ref DHCP_HOPS
+    uint32_t xid;           ///< @ref DHCP_XID  This increase one every DHCP transaction.
+    uint16_t secs;          ///< @ref DHCP_SECS
+    uint16_t flags;         ///< @ref DHCP_FLAGSBROADCAST or @ref DHCP_FLAGSUNICAST
+    uint8_t  ciaddr[4];     ///< @ref Request IP to DHCP sever
+    uint8_t  yiaddr[4];     ///< @ref Offered IP from DHCP server
+    uint8_t  siaddr[4];     ///< No use
+    uint8_t  giaddr[4];     ///< No use
+    uint8_t  chaddr[16];    ///< DHCP client 6bytes MAC address. Others is filled to zero
+    uint8_t  sname[64];     ///< No use
+    uint8_t  file[128];     ///< No use
+    uint8_t  OPT[OPT_SIZE]; ///< Option
+} RIP_MSG;
+
+
+
+uint8_t DHCP_SOCKET;                      // Socket number for DHCP
+
+uint8_t DHCP_SIP[4];                      // DHCP Server IP address
+uint8_t DHCP_REAL_SIP[4];                 // For extract my DHCP server in a few DHCP server
+
+// Network information from DHCP Server
+uint8_t OLD_allocated_ip[4]   = {0, };    // Previous IP address
+uint8_t DHCP_allocated_ip[4]  = {0, };    // IP address from DHCP
+uint8_t DHCP_allocated_gw[4]  = {0, };    // Gateway address from DHCP
+uint8_t DHCP_allocated_sn[4]  = {0, };    // Subnet mask from DHCP
+uint8_t DHCP_allocated_dns[4] = {0, };    // DNS address from DHCP
+
+
+int8_t   dhcp_state        = STATE_DHCP_INIT;   // DHCP state
+int8_t   dhcp_retry_count  = 0;
+
+uint32_t dhcp_lease_time   			= INFINITE_LEASETIME;
+volatile uint32_t dhcp_tick_1s      = 0;                 // unit 1 second
+uint32_t dhcp_tick_next    			= DHCP_WAIT_TIME ;
+
+uint32_t DHCP_XID;      // Any number
+
+RIP_MSG* pDHCPMSG;      // Buffer pointer for DHCP processing
+
+uint8_t HOST_NAME[] = DCHP_HOST_NAME;
+
+uint8_t DHCP_CHADDR[6]; // DHCP Client MAC address.
+
+/* The default callback function */
+void default_ip_assign(void);
+void default_ip_update(void);
+void default_ip_conflict(void);
+
+/* Callback handler */
+void (*dhcp_ip_assign)(void)   = default_ip_assign;     /* handler to be called when the IP address from DHCP server is first assigned */
+void (*dhcp_ip_update)(void)   = default_ip_update;     /* handler to be called when the IP address from DHCP server is updated */
+void (*dhcp_ip_conflict)(void) = default_ip_conflict;   /* handler to be called when the IP address from DHCP server is conflict */
+
+void reg_dhcp_cbfunc(void(*ip_assign)(void), void(*ip_update)(void), void(*ip_conflict)(void));
+
+char NibbleToHex(uint8_t nibble);
+
+/* send DISCOVER message to DHCP server */
+void     send_DHCP_DISCOVER(void);
+
+/* send REQEUST message to DHCP server */
+void     send_DHCP_REQUEST(void);
+
+/* send DECLINE message to DHCP server */
+void     send_DHCP_DECLINE(void);
+
+/* IP conflict check by sending ARP-request to leased IP and wait ARP-response. */
+int8_t   check_DHCP_leasedIP(void);
+
+/* check the timeout in DHCP process */
+uint8_t  check_DHCP_timeout(void);
+
+/* Initialize to timeout process.  */
+void     reset_DHCP_timeout(void);
+
+/* Parse message as OFFER and ACK and NACK from DHCP server.*/
+int8_t   parseDHCPCMSG(void);
+
+/* The default handler of ip assign first */
+void default_ip_assign(void) {
+    setSIPR(DHCP_allocated_ip);
+    setSUBR(DHCP_allocated_sn);
+    setGAR (DHCP_allocated_gw);
+}
+
+/* The default handler of ip changed */
+void default_ip_update(void) {
+    /* WIZchip Software Reset */
+#if 1
+    // 20231019 taylor//teddy 240122
+#if (_WIZCHIP_ == 6100)||(_WIZCHIP_ == 6300)
+    CHIPUNLOCK();
+    setSYCR0(SYCR0_RST);
+    CHIPLOCK();
+    getSYSR();
+#else
+    setMR(MR_RST);
+    getMR(); // for delay
+#endif
+#else
+    setMR(MR_RST);
+    getMR(); // for delay
+#endif
+    default_ip_assign();
+#if _WIZCHIP_ == W6100
+    NETUNLOCK();
+    setSHAR(DHCP_CHADDR);
+    NETLOCK();
+#else
+    setSHAR(DHCP_CHADDR);
+#endif
+}
+
+/* The default handler of ip changed */
+void default_ip_conflict(void) {
+    // WIZchip Software Reset
+#if 1
+    // 20231019 taylor//teddy 240122
+#if (_WIZCHIP_ == 6100)||(_WIZCHIP_ == 6300)
+    // 20231019 taylor
+    CHIPUNLOCK();
+    setSYCR0(SYCR0_RST);
+    CHIPLOCK();
+    getSYSR();
+#else
+    setMR(MR_RST);
+    getMR(); // for delay
+#endif
+#else
+    setMR(MR_RST);
+    getMR(); // for delay
+#endif
+#if _WIZCHIP_ == W6100
+    NETUNLOCK();
+    setSHAR(DHCP_CHADDR);
+    NETLOCK();
+#else
+    setSHAR(DHCP_CHADDR);
+#endif
+}
+
+/* register the call back func. */
+void reg_dhcp_cbfunc(void(*ip_assign)(void), void(*ip_update)(void), void(*ip_conflict)(void)) {
+    dhcp_ip_assign   = default_ip_assign;
+    dhcp_ip_update   = default_ip_update;
+    dhcp_ip_conflict = default_ip_conflict;
+    if (ip_assign) {
+        dhcp_ip_assign = ip_assign;
+    }
+    if (ip_update) {
+        dhcp_ip_update = ip_update;
+    }
+    if (ip_conflict) {
+        dhcp_ip_conflict = ip_conflict;
+    }
+}
+
+/* make the common DHCP message */
+void makeDHCPMSG(void) {
+    uint8_t  bk_mac[6];
+    uint8_t* ptmp;
+    uint8_t  i;
+    getSHAR(bk_mac);
+    pDHCPMSG->op      = DHCP_BOOTREQUEST;
+    pDHCPMSG->htype   = DHCP_HTYPE10MB;
+    pDHCPMSG->hlen    = DHCP_HLENETHERNET;
+    pDHCPMSG->hops    = DHCP_HOPS;
+    ptmp              = (uint8_t*)(&pDHCPMSG->xid);
+    *(ptmp + 0)         = (uint8_t)((DHCP_XID & 0xFF000000) >> 24);
+    *(ptmp + 1)         = (uint8_t)((DHCP_XID & 0x00FF0000) >> 16);
+    *(ptmp + 2)         = (uint8_t)((DHCP_XID & 0x0000FF00) >>  8);
+    *(ptmp + 3)         = (uint8_t)((DHCP_XID & 0x000000FF) >>  0);
+    pDHCPMSG->secs    = DHCP_SECS;
+    ptmp              = (uint8_t*)(&pDHCPMSG->flags);
+    *(ptmp + 0)         = (uint8_t)((DHCP_FLAGSBROADCAST & 0xFF00) >> 8);
+    *(ptmp + 1)         = (uint8_t)((DHCP_FLAGSBROADCAST & 0x00FF) >> 0);
+
+    pDHCPMSG->ciaddr[0] = 0;
+    pDHCPMSG->ciaddr[1] = 0;
+    pDHCPMSG->ciaddr[2] = 0;
+    pDHCPMSG->ciaddr[3] = 0;
+
+    pDHCPMSG->yiaddr[0] = 0;
+    pDHCPMSG->yiaddr[1] = 0;
+    pDHCPMSG->yiaddr[2] = 0;
+    pDHCPMSG->yiaddr[3] = 0;
+
+    pDHCPMSG->siaddr[0] = 0;
+    pDHCPMSG->siaddr[1] = 0;
+    pDHCPMSG->siaddr[2] = 0;
+    pDHCPMSG->siaddr[3] = 0;
+
+    pDHCPMSG->giaddr[0] = 0;
+    pDHCPMSG->giaddr[1] = 0;
+    pDHCPMSG->giaddr[2] = 0;
+    pDHCPMSG->giaddr[3] = 0;
+
+    pDHCPMSG->chaddr[0] = DHCP_CHADDR[0];
+    pDHCPMSG->chaddr[1] = DHCP_CHADDR[1];
+    pDHCPMSG->chaddr[2] = DHCP_CHADDR[2];
+    pDHCPMSG->chaddr[3] = DHCP_CHADDR[3];
+    pDHCPMSG->chaddr[4] = DHCP_CHADDR[4];
+    pDHCPMSG->chaddr[5] = DHCP_CHADDR[5];
+
+    for (i = 6; i < 16; i++) {
+        pDHCPMSG->chaddr[i] = 0;
+    }
+    for (i = 0; i < 64; i++) {
+        pDHCPMSG->sname[i]  = 0;
+    }
+    for (i = 0; i < 128; i++) {
+        pDHCPMSG->file[i]   = 0;
+    }
+
+    // MAGIC_COOKIE
+    pDHCPMSG->OPT[0] = (uint8_t)((MAGIC_COOKIE & 0xFF000000) >> 24);
+    pDHCPMSG->OPT[1] = (uint8_t)((MAGIC_COOKIE & 0x00FF0000) >> 16);
+    pDHCPMSG->OPT[2] = (uint8_t)((MAGIC_COOKIE & 0x0000FF00) >>  8);
+    pDHCPMSG->OPT[3] = (uint8_t) (MAGIC_COOKIE & 0x000000FF) >>  0;
+}
+
+/* SEND DHCP DISCOVER */
+void send_DHCP_DISCOVER(void) {
+    uint16_t i;
+    uint8_t ip[4];
+    uint16_t k = 0;
+
+    makeDHCPMSG();
+    DHCP_SIP[0] = 0;
+    DHCP_SIP[1] = 0;
+    DHCP_SIP[2] = 0;
+    DHCP_SIP[3] = 0;
+    DHCP_REAL_SIP[0] = 0;
+    DHCP_REAL_SIP[1] = 0;
+    DHCP_REAL_SIP[2] = 0;
+    DHCP_REAL_SIP[3] = 0;
+
+    k = 4;     // because MAGIC_COOKIE already made by makeDHCPMSG()
+
+    // Option Request Param
+    pDHCPMSG->OPT[k++] = dhcpMessageType;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_DISCOVER;
+
+    // Client identifier
+    pDHCPMSG->OPT[k++] = dhcpClientIdentifier;
+    pDHCPMSG->OPT[k++] = 0x07;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[0];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[1];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[2];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[3];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
+
+    // host name
+    pDHCPMSG->OPT[k++] = hostName;
+    pDHCPMSG->OPT[k++] = 0;          // fill zero length of hostname
+    for (i = 0 ; HOST_NAME[i] != 0; i++) {
+        pDHCPMSG->OPT[k++] = HOST_NAME[i];
+    }
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3]);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4]);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5]);
+    pDHCPMSG->OPT[k - (i + 6 + 1)] = i + 6; // length of hostname
+
+    pDHCPMSG->OPT[k++] = dhcpParamRequest;
+    pDHCPMSG->OPT[k++] = 0x06;	// length of request
+    pDHCPMSG->OPT[k++] = subnetMask;
+    pDHCPMSG->OPT[k++] = routersOnSubnet;
+    pDHCPMSG->OPT[k++] = dns;
+    pDHCPMSG->OPT[k++] = domainName;
+    pDHCPMSG->OPT[k++] = dhcpT1value;
+    pDHCPMSG->OPT[k++] = dhcpT2value;
+    pDHCPMSG->OPT[k++] = endOption;
+
+    for (i = k; i < OPT_SIZE; i++) {
+        pDHCPMSG->OPT[i] = 0;
+    }
+
+    // send broadcasting packet
+    ip[0] = 255;
+    ip[1] = 255;
+    ip[2] = 255;
+    ip[3] = 255;
+
+#ifdef _DHCP_DEBUG_
+    printf("> Send DHCP_DISCOVER\r\n");
+#endif
+
+#if 1
+    // 20231016 taylor//teddy 240122
+#if ((_WIZCHIP_ == 6100)|| (_WIZCHIP_ == 6300))
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT, 4);
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+}
+
+/* SEND DHCP REQUEST */
+void send_DHCP_REQUEST(void) {
+    int i;
+    uint8_t ip[4];
+    uint16_t k = 0;
+
+    makeDHCPMSG();
+
+    if (dhcp_state == STATE_DHCP_LEASED || dhcp_state == STATE_DHCP_REREQUEST) {
+        *((uint8_t*)(&pDHCPMSG->flags))   = ((DHCP_FLAGSUNICAST & 0xFF00) >> 8);
+        *((uint8_t*)(&pDHCPMSG->flags) +1) = (DHCP_FLAGSUNICAST & 0x00FF);
+        pDHCPMSG->ciaddr[0] = DHCP_allocated_ip[0];
+        pDHCPMSG->ciaddr[1] = DHCP_allocated_ip[1];
+        pDHCPMSG->ciaddr[2] = DHCP_allocated_ip[2];
+        pDHCPMSG->ciaddr[3] = DHCP_allocated_ip[3];
+        ip[0] = DHCP_SIP[0];
+        ip[1] = DHCP_SIP[1];
+        ip[2] = DHCP_SIP[2];
+        ip[3] = DHCP_SIP[3];
+    } else {
+        ip[0] = 255;
+        ip[1] = 255;
+        ip[2] = 255;
+        ip[3] = 255;
+    }
+
+    k = 4;      // because MAGIC_COOKIE already made by makeDHCPMSG()
+
+    // Option Request Param.
+    pDHCPMSG->OPT[k++] = dhcpMessageType;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_REQUEST;
+
+    pDHCPMSG->OPT[k++] = dhcpClientIdentifier;
+    pDHCPMSG->OPT[k++] = 0x07;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[0];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[1];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[2];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[3];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
+
+    if (ip[3] == 255) { // if(dchp_state == STATE_DHCP_LEASED || dchp_state == DHCP_REREQUEST_STATE)
+        pDHCPMSG->OPT[k++] = dhcpRequestedIPaddr;
+        pDHCPMSG->OPT[k++] = 0x04;
+        pDHCPMSG->OPT[k++] = DHCP_allocated_ip[0];
+        pDHCPMSG->OPT[k++] = DHCP_allocated_ip[1];
+        pDHCPMSG->OPT[k++] = DHCP_allocated_ip[2];
+        pDHCPMSG->OPT[k++] = DHCP_allocated_ip[3];
+
+        pDHCPMSG->OPT[k++] = dhcpServerIdentifier;
+        pDHCPMSG->OPT[k++] = 0x04;
+        pDHCPMSG->OPT[k++] = DHCP_SIP[0];
+        pDHCPMSG->OPT[k++] = DHCP_SIP[1];
+        pDHCPMSG->OPT[k++] = DHCP_SIP[2];
+        pDHCPMSG->OPT[k++] = DHCP_SIP[3];
+    }
+
+    // host name
+    pDHCPMSG->OPT[k++] = hostName;
+    pDHCPMSG->OPT[k++] = 0; // length of hostname
+    for (i = 0 ; HOST_NAME[i] != 0; i++) {
+        pDHCPMSG->OPT[k++] = HOST_NAME[i];
+    }
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3]);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4]);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5] >> 4);
+    pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5]);
+    pDHCPMSG->OPT[k - (i + 6 + 1)] = i + 6; // length of hostname
+
+    pDHCPMSG->OPT[k++] = dhcpParamRequest;
+    pDHCPMSG->OPT[k++] = 0x08;
+    pDHCPMSG->OPT[k++] = subnetMask;
+    pDHCPMSG->OPT[k++] = routersOnSubnet;
+    pDHCPMSG->OPT[k++] = dns;
+    pDHCPMSG->OPT[k++] = domainName;
+    pDHCPMSG->OPT[k++] = dhcpT1value;
+    pDHCPMSG->OPT[k++] = dhcpT2value;
+    pDHCPMSG->OPT[k++] = performRouterDiscovery;
+    pDHCPMSG->OPT[k++] = staticRoute;
+    pDHCPMSG->OPT[k++] = endOption;
+
+    for (i = k; i < OPT_SIZE; i++) {
+        pDHCPMSG->OPT[i] = 0;
+    }
+
+#ifdef _DHCP_DEBUG_
+    printf("> Send DHCP_REQUEST\r\n");
+#endif
+
+#if 1
+    // 20231016 taylor//teddy 240122
+#if ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT, 4);
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+
+}
+
+/* SEND DHCP DHCPDECLINE */
+void send_DHCP_DECLINE(void) {
+    int i;
+    uint8_t ip[4];
+    uint16_t k = 0;
+
+    makeDHCPMSG();
+
+    k = 4;      // because MAGIC_COOKIE already made by makeDHCPMSG()
+
+    *((uint8_t*)(&pDHCPMSG->flags))   = ((DHCP_FLAGSUNICAST & 0xFF00) >> 8);
+    *((uint8_t*)(&pDHCPMSG->flags) +1) = (DHCP_FLAGSUNICAST & 0x00FF);
+
+    // Option Request Param.
+    pDHCPMSG->OPT[k++] = dhcpMessageType;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_DECLINE;
+
+    pDHCPMSG->OPT[k++] = dhcpClientIdentifier;
+    pDHCPMSG->OPT[k++] = 0x07;
+    pDHCPMSG->OPT[k++] = 0x01;
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[0];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[1];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[2];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[3];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
+    pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
+
+    pDHCPMSG->OPT[k++] = dhcpRequestedIPaddr;
+    pDHCPMSG->OPT[k++] = 0x04;
+    pDHCPMSG->OPT[k++] = DHCP_allocated_ip[0];
+    pDHCPMSG->OPT[k++] = DHCP_allocated_ip[1];
+    pDHCPMSG->OPT[k++] = DHCP_allocated_ip[2];
+    pDHCPMSG->OPT[k++] = DHCP_allocated_ip[3];
+
+    pDHCPMSG->OPT[k++] = dhcpServerIdentifier;
+    pDHCPMSG->OPT[k++] = 0x04;
+    pDHCPMSG->OPT[k++] = DHCP_SIP[0];
+    pDHCPMSG->OPT[k++] = DHCP_SIP[1];
+    pDHCPMSG->OPT[k++] = DHCP_SIP[2];
+    pDHCPMSG->OPT[k++] = DHCP_SIP[3];
+
+    pDHCPMSG->OPT[k++] = endOption;
+
+    for (i = k; i < OPT_SIZE; i++) {
+        pDHCPMSG->OPT[i] = 0;
+    }
+
+    //send broadcasting packet
+    ip[0] = 0xFF;
+    ip[1] = 0xFF;
+    ip[2] = 0xFF;
+    ip[3] = 0xFF;
+
+#ifdef _DHCP_DEBUG_
+    printf("\r\n> Send DHCP_DECLINE\r\n");
+#endif
+
+#if 1
+    // 20231016 taylor//teddy 240122
+#if ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT, 4);
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+#else
+    sendto(DHCP_SOCKET, (uint8_t *)pDHCPMSG, RIP_MSG_SIZE, ip, DHCP_SERVER_PORT);
+#endif
+}
+
+/* PARSE REPLY pDHCPMSG */
+int8_t parseDHCPMSG(void) {
+    uint8_t svr_addr[6];
+    uint16_t  svr_port;
+    uint16_t len;
+
+    uint8_t * p;
+    uint8_t * e;
+    uint8_t type = 0;
+    uint8_t opt_len;
+#if 1
+    // 20231019 taylor
+    uint8_t addr_len;
+#endif
+
+    if ((len = getSn_RX_RSR(DHCP_SOCKET)) > 0) {
+#if 1
+        // 20231019 taylor//teddy 240122
+#if ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+        len = recvfrom(DHCP_SOCKET, (uint8_t *)pDHCPMSG, len, svr_addr, &svr_port, &addr_len);
+#else
+        len = recvfrom(DHCP_SOCKET, (uint8_t *)pDHCPMSG, len, svr_addr, &svr_port);
+#endif
+#else
+        len = recvfrom(DHCP_SOCKET, (uint8_t *)pDHCPMSG, len, svr_addr, &svr_port);
+#endif
+#ifdef _DHCP_DEBUG_
+        printf("DHCP message : %d.%d.%d.%d(%d) %d received. \r\n", svr_addr[0], svr_addr[1], svr_addr[2], svr_addr[3], svr_port, len);
+#endif
+    } else {
+        return 0;
+    }
+    if (svr_port == DHCP_SERVER_PORT) {
+        // compare mac address
+        if ((pDHCPMSG->chaddr[0] != DHCP_CHADDR[0]) || (pDHCPMSG->chaddr[1] != DHCP_CHADDR[1]) ||
+                (pDHCPMSG->chaddr[2] != DHCP_CHADDR[2]) || (pDHCPMSG->chaddr[3] != DHCP_CHADDR[3]) ||
+                (pDHCPMSG->chaddr[4] != DHCP_CHADDR[4]) || (pDHCPMSG->chaddr[5] != DHCP_CHADDR[5])) {
+#ifdef _DHCP_DEBUG_
+            printf("No My DHCP Message. This message is ignored.\r\n");
+#endif
+            return 0;
+        }
+        //compare DHCP server ip address
+        if ((DHCP_SIP[0] != 0) || (DHCP_SIP[1] != 0) || (DHCP_SIP[2] != 0) || (DHCP_SIP[3] != 0)) {
+            if (((svr_addr[0] != DHCP_SIP[0]) || (svr_addr[1] != DHCP_SIP[1]) || (svr_addr[2] != DHCP_SIP[2]) || (svr_addr[3] != DHCP_SIP[3])) &&
+                    ((svr_addr[0] != DHCP_REAL_SIP[0]) || (svr_addr[1] != DHCP_REAL_SIP[1]) || (svr_addr[2] != DHCP_REAL_SIP[2]) || (svr_addr[3] != DHCP_REAL_SIP[3]))) {
+#ifdef _DHCP_DEBUG_
+                printf("Another DHCP sever send a response message. This is ignored.\r\n");
+#endif
+                return 0;
+            }
+        }
+        p = (uint8_t *)(&pDHCPMSG->op);
+        p = p + 240;      // 240 = sizeof(RIP_MSG) + MAGIC_COOKIE size in RIP_MSG.opt - sizeof(RIP_MSG.opt)
+        e = p + (len - 240);
+
+        while (p < e) {
+
+            switch (*p) {
+
+            case endOption :
+                p = e;   // for break while(p < e)
+                break;
+            case padOption :
+                p++;
+                break;
+            case dhcpMessageType :
+                p++;
+                p++;
+                type = *p++;
+                break;
+            case subnetMask :
+                p++;
+                p++;
+                DHCP_allocated_sn[0] = *p++;
+                DHCP_allocated_sn[1] = *p++;
+                DHCP_allocated_sn[2] = *p++;
+                DHCP_allocated_sn[3] = *p++;
+                break;
+            case routersOnSubnet :
+                p++;
+                opt_len = *p++;
+                DHCP_allocated_gw[0] = *p++;
+                DHCP_allocated_gw[1] = *p++;
+                DHCP_allocated_gw[2] = *p++;
+                DHCP_allocated_gw[3] = *p++;
+                p = p + (opt_len - 4);
+                break;
+            case dns :
+                p++;
+                opt_len = *p++;
+                DHCP_allocated_dns[0] = *p++;
+                DHCP_allocated_dns[1] = *p++;
+                DHCP_allocated_dns[2] = *p++;
+                DHCP_allocated_dns[3] = *p++;
+                p = p + (opt_len - 4);
+                break;
+            case dhcpIPaddrLeaseTime :
+                p++;
+                opt_len = *p++;
+                dhcp_lease_time  = *p++;
+                dhcp_lease_time  = (dhcp_lease_time << 8) + *p++;
+                dhcp_lease_time  = (dhcp_lease_time << 8) + *p++;
+                dhcp_lease_time  = (dhcp_lease_time << 8) + *p++;
+#ifdef _DHCP_DEBUG_
+                dhcp_lease_time = 10;
+#endif
+                break;
+            case dhcpServerIdentifier :
+                p++;
+                opt_len = *p++;
+                DHCP_SIP[0] = *p++;
+                DHCP_SIP[1] = *p++;
+                DHCP_SIP[2] = *p++;
+                DHCP_SIP[3] = *p++;
+                DHCP_REAL_SIP[0] = svr_addr[0];
+                DHCP_REAL_SIP[1] = svr_addr[1];
+                DHCP_REAL_SIP[2] = svr_addr[2];
+                DHCP_REAL_SIP[3] = svr_addr[3];
+                break;
+            default :
+                p++;
+                opt_len = *p++;
+                p += opt_len;
+                break;
+            } // switch
+        } // while
+    } // if
+    return	type;
+}
+
+uint8_t DHCP_run(void) {
+    uint8_t  type;
+    uint8_t  ret;
+
+    if (dhcp_state == STATE_DHCP_STOP) {
+        return DHCP_STOPPED;
+    }
+
+    if (getSn_SR(DHCP_SOCKET) != SOCK_UDP) {
+        socket(DHCP_SOCKET, Sn_MR_UDP, DHCP_CLIENT_PORT, 0x00);
+    }
+
+    ret = DHCP_RUNNING;
+    type = parseDHCPMSG();
+
+    switch (dhcp_state) {
+    case STATE_DHCP_INIT     :
+        DHCP_allocated_ip[0] = 0;
+        DHCP_allocated_ip[1] = 0;
+        DHCP_allocated_ip[2] = 0;
+        DHCP_allocated_ip[3] = 0;
+        send_DHCP_DISCOVER();
+        dhcp_state = STATE_DHCP_DISCOVER;
+        break;
+    case STATE_DHCP_DISCOVER :
+        if (type == DHCP_OFFER) {
+#ifdef _DHCP_DEBUG_
+            printf("> Receive DHCP_OFFER\r\n");
+#endif
+            DHCP_allocated_ip[0] = pDHCPMSG->yiaddr[0];
+            DHCP_allocated_ip[1] = pDHCPMSG->yiaddr[1];
+            DHCP_allocated_ip[2] = pDHCPMSG->yiaddr[2];
+            DHCP_allocated_ip[3] = pDHCPMSG->yiaddr[3];
+
+            send_DHCP_REQUEST();
+            dhcp_state = STATE_DHCP_REQUEST;
+        } else {
+            ret = check_DHCP_timeout();
+        }
+        break;
+
+    case STATE_DHCP_REQUEST :
+        if (type == DHCP_ACK) {
+
+#ifdef _DHCP_DEBUG_
+            printf("> Receive DHCP_ACK\r\n");
+#endif
+            if (check_DHCP_leasedIP()) {
+                // Network info assignment from DHCP
+                dhcp_ip_assign();
+                reset_DHCP_timeout();
+
+                dhcp_state = STATE_DHCP_LEASED;
+            } else {
+                // IP address conflict occurred
+                reset_DHCP_timeout();
+                dhcp_ip_conflict();
+                dhcp_state = STATE_DHCP_INIT;
+            }
+        } else if (type == DHCP_NAK) {
+
+#ifdef _DHCP_DEBUG_
+            printf("> Receive DHCP_NACK\r\n");
+#endif
+
+            reset_DHCP_timeout();
+
+            dhcp_state = STATE_DHCP_DISCOVER;
+        } else {
+            ret = check_DHCP_timeout();
+        }
+        break;
+
+    case STATE_DHCP_LEASED :
+        ret = DHCP_IP_LEASED;
+        if ((dhcp_lease_time != INFINITE_LEASETIME) && ((dhcp_lease_time / 2) < dhcp_tick_1s)) {
+
+#ifdef _DHCP_DEBUG_
+            printf("> Maintains the IP address \r\n");
+#endif
+
+            type = 0;
+            OLD_allocated_ip[0] = DHCP_allocated_ip[0];
+            OLD_allocated_ip[1] = DHCP_allocated_ip[1];
+            OLD_allocated_ip[2] = DHCP_allocated_ip[2];
+            OLD_allocated_ip[3] = DHCP_allocated_ip[3];
+
+            DHCP_XID++;
+
+            send_DHCP_REQUEST();
+
+            reset_DHCP_timeout();
+
+            dhcp_state = STATE_DHCP_REREQUEST;
+        }
+        break;
+
+    case STATE_DHCP_REREQUEST :
+        ret = DHCP_IP_LEASED;
+        if (type == DHCP_ACK) {
+            dhcp_retry_count = 0;
+            if (OLD_allocated_ip[0] != DHCP_allocated_ip[0] ||
+                    OLD_allocated_ip[1] != DHCP_allocated_ip[1] ||
+                    OLD_allocated_ip[2] != DHCP_allocated_ip[2] ||
+                    OLD_allocated_ip[3] != DHCP_allocated_ip[3]) {
+                ret = DHCP_IP_CHANGED;
+                dhcp_ip_update();
+#ifdef _DHCP_DEBUG_
+                printf(">IP changed.\r\n");
+#endif
+
+            }
+#ifdef _DHCP_DEBUG_
+            else {
+                printf(">IP is continued.\r\n");
+            }
+#endif
+            reset_DHCP_timeout();
+            dhcp_state = STATE_DHCP_LEASED;
+        } else if (type == DHCP_NAK) {
+
+#ifdef _DHCP_DEBUG_
+            printf("> Receive DHCP_NACK, Failed to maintain ip\r\n");
+#endif
+
+            reset_DHCP_timeout();
+
+            dhcp_state = STATE_DHCP_DISCOVER;
+        } else {
+            ret = check_DHCP_timeout();
+        }
+        break;
+    default :
+        break;
+    }
+
+    return ret;
+}
+
+void    DHCP_stop(void) {
+    close(DHCP_SOCKET);
+    dhcp_state = STATE_DHCP_STOP;
+}
+
+uint8_t check_DHCP_timeout(void) {
+    uint8_t ret = DHCP_RUNNING;
+
+    if (dhcp_retry_count < MAX_DHCP_RETRY) {
+        if (dhcp_tick_next < dhcp_tick_1s) {
+
+            switch (dhcp_state) {
+            case STATE_DHCP_DISCOVER :
+                //					printf("<<timeout>> state : STATE_DHCP_DISCOVER\r\n");
+                send_DHCP_DISCOVER();
+                break;
+
+            case STATE_DHCP_REQUEST :
+                //					printf("<<timeout>> state : STATE_DHCP_REQUEST\r\n");
+
+                send_DHCP_REQUEST();
+                break;
+
+            case STATE_DHCP_REREQUEST :
+                //					printf("<<timeout>> state : STATE_DHCP_REREQUEST\r\n");
+
+                send_DHCP_REQUEST();
+                break;
+
+            default :
+                break;
+            }
+
+            dhcp_tick_1s = 0;
+            dhcp_tick_next = dhcp_tick_1s + DHCP_WAIT_TIME;
+            dhcp_retry_count++;
+        }
+    } else { // timeout occurred
+
+        switch (dhcp_state) {
+        case STATE_DHCP_DISCOVER:
+            dhcp_state = STATE_DHCP_INIT;
+            ret = DHCP_FAILED;
+            break;
+        case STATE_DHCP_REQUEST:
+        case STATE_DHCP_REREQUEST:
+            send_DHCP_DISCOVER();
+            dhcp_state = STATE_DHCP_DISCOVER;
+            break;
+        default :
+            break;
+        }
+        reset_DHCP_timeout();
+    }
+    return ret;
+}
+
+int8_t check_DHCP_leasedIP(void) {
+    uint8_t tmp;
+    int32_t ret;
+
+    //WIZchip RCR value changed for ARP Timeout count control
+    tmp = getRCR();
+    setRCR(0x03);
+
+    // IP conflict detection : ARP request - ARP reply
+    // Broadcasting ARP Request for check the IP conflict using UDP sendto() function
+#if 1
+    // 20231016 taylor//teddy 240122
+#if ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
+    ret = sendto(DHCP_SOCKET, (uint8_t *)"CHECK_IP_CONFLICT", 17, DHCP_allocated_ip, 5000, 4);
+#else
+    ret = sendto(DHCP_SOCKET, (uint8_t *)"CHECK_IP_CONFLICT", 17, DHCP_allocated_ip, 5000);
+#endif
+#else
+    ret = sendto(DHCP_SOCKET, (uint8_t *)"CHECK_IP_CONFLICT", 17, DHCP_allocated_ip, 5000);
+#endif
+
+    // RCR value restore
+    setRCR(tmp);
+
+    if (ret == SOCKERR_TIMEOUT) {
+        // UDP send Timeout occurred : allocated IP address is unique, DHCP Success
+
+#ifdef _DHCP_DEBUG_
+        printf("\r\n> Check leased IP - OK\r\n");
+#endif
+
+        return 1;
+    } else {
+        // Received ARP reply or etc : IP address conflict occur, DHCP Failed
+        send_DHCP_DECLINE();
+
+        ret = dhcp_tick_1s;
+        while ((dhcp_tick_1s - ret) < 2) ;  // wait for 1s over; wait to complete to send DECLINE message;
+
+        return 0;
+    }
+}
+
+void DHCP_init(uint8_t s, uint8_t * buf) {
+    uint8_t zeroip[4] = {0, 0, 0, 0};
+    getSHAR(DHCP_CHADDR);
+    if ((DHCP_CHADDR[0] | DHCP_CHADDR[1]  | DHCP_CHADDR[2] | DHCP_CHADDR[3] | DHCP_CHADDR[4] | DHCP_CHADDR[5]) == 0x00) {
+        // assigning temporary mac address, you should be set SHAR before call this function.
+        DHCP_CHADDR[0] = 0x00;
+        DHCP_CHADDR[1] = 0x08;
+        DHCP_CHADDR[2] = 0xdc;
+        DHCP_CHADDR[3] = 0x00;
+        DHCP_CHADDR[4] = 0x00;
+        DHCP_CHADDR[5] = 0x00;
+#if _WIZCHIP_ == W6100
+        NETUNLOCK();
+        setSHAR(DHCP_CHADDR);
+        NETLOCK();
+#else
+        setSHAR(DHCP_CHADDR);
+#endif
+    }
+
+    DHCP_SOCKET = s; // SOCK_DHCP
+    pDHCPMSG = (RIP_MSG*)buf;
+    DHCP_XID = 0x12345678;
+    {
+        DHCP_XID += DHCP_CHADDR[3];
+        DHCP_XID += DHCP_CHADDR[4];
+        DHCP_XID += DHCP_CHADDR[5];
+        DHCP_XID += (DHCP_CHADDR[3] ^ DHCP_CHADDR[4] ^ DHCP_CHADDR[5]);
+    }
+    // WIZchip Netinfo Clear
+    setSIPR(zeroip);
+    setGAR(zeroip);
+
+    reset_DHCP_timeout();
+    dhcp_state = STATE_DHCP_INIT;
+}
+
+
+/* Reset the DHCP timeout count and retry count. */
+void reset_DHCP_timeout(void) {
+    dhcp_tick_1s = 0;
+    dhcp_tick_next = DHCP_WAIT_TIME;
+    dhcp_retry_count = 0;
+}
+
+void DHCP_time_handler(void) {
+    dhcp_tick_1s++;
+}
+
+void getIPfromDHCP(uint8_t* ip) {
+    ip[0] = DHCP_allocated_ip[0];
+    ip[1] = DHCP_allocated_ip[1];
+    ip[2] = DHCP_allocated_ip[2];
+    ip[3] = DHCP_allocated_ip[3];
+}
+
+void getGWfromDHCP(uint8_t* ip) {
+    ip[0] = DHCP_allocated_gw[0];
+    ip[1] = DHCP_allocated_gw[1];
+    ip[2] = DHCP_allocated_gw[2];
+    ip[3] = DHCP_allocated_gw[3];
+}
+
+void getSNfromDHCP(uint8_t* ip) {
+    ip[0] = DHCP_allocated_sn[0];
+    ip[1] = DHCP_allocated_sn[1];
+    ip[2] = DHCP_allocated_sn[2];
+    ip[3] = DHCP_allocated_sn[3];
+}
+
+void getDNSfromDHCP(uint8_t* ip) {
+    ip[0] = DHCP_allocated_dns[0];
+    ip[1] = DHCP_allocated_dns[1];
+    ip[2] = DHCP_allocated_dns[2];
+    ip[3] = DHCP_allocated_dns[3];
+}
+
+uint32_t getDHCPLeasetime(void) {
+    return dhcp_lease_time;
+}
+
+char NibbleToHex(uint8_t nibble) {
+    nibble &= 0x0F;
+    if (nibble <= 9) {
+        return nibble + '0';
+    } else {
+        return nibble + ('A' - 0x0A);
+    }
+}
+
+

--- a/third_party/ioLibrary_Driver/Internet/DHCP/dhcp.h
+++ b/third_party/ioLibrary_Driver/Internet/DHCP/dhcp.h
@@ -1,0 +1,163 @@
+//*****************************************************************************
+//
+//! \file dhcp.h
+//! \brief DHCP APIs Header file.
+//! \details Processig DHCP protocol as DISCOVER, OFFER, REQUEST, ACK, NACK and DECLINE.
+//! \version 1.1.1
+//! \date 2019/10/08
+//! \par  Revision history
+//!       <2019/10/08> compare DHCP server ip address
+//!       <2013/11/18> 1st Release
+//!       <2012/12/20> V1.1.0
+//!         1. Move unreferenced DEFINE to dhcp.c
+//!       <2012/12/26> V1.1.1
+//! \author Eric Jung & MidnightCow
+//! \copyright
+//!
+//! Copyright (c)  2013, WIZnet Co., LTD.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions
+//! are met:
+//!
+//!     * Redistributions of source code must retain the above copyright
+//! notice, this list of conditions and the following disclaimer.
+//!     * Redistributions in binary form must reproduce the above copyright
+//! notice, this list of conditions and the following disclaimer in the
+//! documentation and/or other materials provided with the distribution.
+//!     * Neither the name of the <ORGANIZATION> nor the names of its
+//! contributors may be used to endorse or promote products derived
+//! from this software without specific prior written permission.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+#ifndef _DHCP_H_
+#define _DHCP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+    @brief
+    @details If you want to display debug & processing message, Define _DHCP_DEBUG_
+    @note    If defined, it depends on <stdio.h>
+*/
+#if 0
+// 20231023 taylor
+#define _DHCP_DEBUG_
+#endif
+
+
+/* Retry to processing DHCP */
+#define	MAX_DHCP_RETRY          2        ///< Maximum retry count
+#define	DHCP_WAIT_TIME          10       ///< Wait Time 10s
+
+
+/* UDP port numbers for DHCP */
+#define DHCP_SERVER_PORT      	67	      ///< DHCP server port number
+#define DHCP_CLIENT_PORT         68	      ///< DHCP client port number
+
+
+#define MAGIC_COOKIE             0x63825363  ///< You should not modify it number.
+
+#define DCHP_HOST_NAME           "WIZnet\0"
+
+/*
+    @brief return value of @ref DHCP_run()
+*/
+enum {
+    DHCP_FAILED = 0,  ///< Processing Fail
+    DHCP_RUNNING,     ///< Processing DHCP protocol
+    DHCP_IP_ASSIGN,   ///< First Occupy IP from DHPC server      (if cbfunc == null, act as default default_ip_assign)
+    DHCP_IP_CHANGED,  ///< Change IP address by new ip from DHCP (if cbfunc == null, act as default default_ip_update)
+    DHCP_IP_LEASED,   ///< Stand by
+    DHCP_STOPPED      ///< Stop processing DHCP protocol
+};
+
+/*
+    @brief DHCP client initialization (outside of the main loop)
+    @param s   - socket number
+    @param buf - buffer for processing DHCP message
+*/
+void DHCP_init(uint8_t s, uint8_t * buf);
+
+/*
+    @brief DHCP 1s Tick Timer handler
+    @note SHOULD BE register to your system 1s Tick timer handler
+*/
+void DHCP_time_handler(void);
+
+/*
+    @brief Register call back function
+    @param ip_assign   - callback func when IP is assigned from DHCP server first
+    @param ip_update   - callback func when IP is changed
+    @param ip_conflict - callback func when the assigned IP is conflict with others.
+*/
+void reg_dhcp_cbfunc(void(*ip_assign)(void), void(*ip_update)(void), void(*ip_conflict)(void));
+
+/*
+    @brief DHCP client in the main loop
+    @return    The value is as the follow \n
+              @ref DHCP_FAILED     \n
+              @ref DHCP_RUNNING    \n
+              @ref DHCP_IP_ASSIGN  \n
+              @ref DHCP_IP_CHANGED \n
+  			  @ref DHCP_IP_LEASED  \n
+              @ref DHCP_STOPPED    \n
+
+    @note This function is always called by you main task.
+*/
+uint8_t DHCP_run(void);
+
+/*
+    @brief Stop DHCP processing
+    @note If you want to restart. call DHCP_init() and DHCP_run()
+*/
+void    DHCP_stop(void);
+
+/* Get Network information assigned from DHCP server */
+/*
+    @brief Get IP address
+    @param ip  - IP address to be returned
+*/
+void getIPfromDHCP(uint8_t* ip);
+/*
+    @brief Get Gateway address
+    @param ip  - Gateway address to be returned
+*/
+void getGWfromDHCP(uint8_t* ip);
+/*
+    @brief Get Subnet mask value
+    @param ip  - Subnet mask to be returned
+*/
+void getSNfromDHCP(uint8_t* ip);
+/*
+    @brief Get DNS address
+    @param ip  - DNS address to be returned
+*/
+void getDNSfromDHCP(uint8_t* ip);
+
+/*
+    @brief Get the leased time by DHCP sever
+    @return unit 1s
+*/
+uint32_t getDHCPLeasetime(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _DHCP_H_ */


### PR DESCRIPTION
## Summary

This PR adds support for the W5500-EVB-Pico board.

The W5500-EVB-Pico is an RP2040-based board that provides Ethernet connectivity through the W5500 chip.

### Changes

* Add W5500-EVB-Pico board definition and configuration
* Integrate W5500 Ethernet support
* Add MQTT connectivity support
* Update build configuration for the new target
* Enable network-based communication workflows on the board

### Motivation

The W5500-EVB-Pico is compatible with the Raspberry Pi Pico ecosystem while providing reliable wired Ethernet connectivity. This integration enables Edge Impulse workflows on an RP2040 platform with Ethernet networking capabilities.

### Testing

* Firmware builds successfully for W5500-EVB-Pico
* Verified operation on hardware
* Verified Ethernet connectivity
* Verified MQTT communication

Feedback and guidance on support requirements for this board would be appreciated.
